### PR TITLE
fix: PR 머지 시 빌드 작업이 실행되도록 조건 수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,14 +52,17 @@ jobs:
     name: Test and Build
     needs: [validate]
     if: |
-      github.event_name == 'pull_request' && 
-      !github.event.pull_request.merged
+      (github.event_name == 'pull_request' && !github.event.pull_request.merged) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true && github.base_ref == 'dev') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     outputs:
       apk_path: ${{ steps.build-apk.outputs.apk_path }}
       build_type: ${{ steps.set-build-type.outputs.build_type }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
       
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
## 문제점
- dev 브랜치로 PR 머지 시 version-management 작업만 실행되고 test-and-build 작업이 실행되지 않음
- 결과적으로 베타 릴리즈를 위한 APK가 빌드되지 않음

## 수정사항
1. test-and-build 작업의 실행 조건 확장
   - PR 검증 시 (머지 전)
   - dev 브랜치로 머지 시
   - 릴리즈 태그 푸시 시

2. checkout 단계에 머지 커밋 참조 추가
   - 머지된 코드를 정확하게 체크아웃하기 위함
