### PR TITLE
fix: CI/CD 작업 순서 및 의존성 개선

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -50,12 +50,12 @@ jobs:
   # 테스트 및 빌드 작업 (통합)
   test-and-build:
     name: Test and Build
-    needs: [validate]
     if: |
       (github.event_name == 'pull_request' && !github.event.pull_request.merged) ||
       (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true && github.base_ref == 'dev') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
+    needs: [validate]
     outputs:
       apk_path: ${{ steps.build-apk.outputs.apk_path }}
       build_type: ${{ steps.set-build-type.outputs.build_type }}
@@ -63,6 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
       
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -135,6 +136,7 @@ jobs:
       github.event.pull_request.merged == true && 
       github.base_ref == 'dev'
     runs-on: ubuntu-latest
+    needs: [test-and-build]
     permissions:
       contents: write
       actions: write
@@ -144,6 +146,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Update Version Code
         id: version-update
@@ -213,6 +216,9 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
         
       # 빌드 결과물 다운로드
       - name: Download Build Artifact


### PR DESCRIPTION
## 문제점
- PR 머지 시 test-and-build 작업이 실행되지 않는 문제 발생
- 작업 간 의존성이 명확하지 않음

## 수정사항
1. 작업 순서 및 의존성 수정
   - test-and-build 작업은 PR 검증 시에만 validate 작업에 의존
   - version-management 작업은 test-and-build 작업에 의존하도록 변경

2. checkout 설정 개선
   - fetch-depth: 0 추가하여 전체 히스토리 가져오기
   - 모든 작업에서 머지 커밋 참조 추가
