### PR TITLE
개선: CI/CD 워크플로우 시나리오 개선

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -56,9 +56,8 @@ jobs:
       (github.event_name == 'pull_request' && !github.event.pull_request.merged) ||
       (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
     outputs:
-      apk_path: ${{ steps.build-apk.outputs.apk_path }}
-      build_type: ${{ steps.set-build-type.outputs.build_type }}
-      version_name: ${{ steps.set-version.outputs.version_name }}
+      build_type: ${{ github.base_ref == 'main' && 'release' || 'debug' }}
+      timestamp: ${{ steps.set-timestamp.outputs.value }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,16 +81,14 @@ jobs:
           name: test-results
           path: app/build/reports/tests/testDebugUnitTest/
 
-      # 타임스탬프 생성
-      - name: Generate Timestamp
-        id: timestamp
-        run: echo "timestamp=$(date +%Y%m%d%H%M%S)" >> $GITHUB_OUTPUT
+      - name: Set Timestamp
+        id: set-timestamp
+        run: echo "value=$(date +%Y%m%d%H%M%S)" >> $GITHUB_OUTPUT
 
-      # APK 빌드
       - name: Build APK
         env:
           VERSION_CODE: ${{ vars.VERSION_CODE }}
-          BUILD_TIMESTAMP: ${{ steps.timestamp.outputs.timestamp }}
+          BUILD_TIMESTAMP: ${{ steps.set-timestamp.outputs.value }}
         run: |
           if [[ "${{ github.base_ref }}" == "main" ]]; then
             ./gradlew assembleRelease -Prelease
@@ -99,7 +96,6 @@ jobs:
             ./gradlew assembleDebug
           fi
 
-      # 빌드 결과물 저장
       - name: Upload Build Artifact
         if: |
           github.event_name == 'pull_request_target' && 
@@ -107,8 +103,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-output
-          path: |
-            app/build/outputs/apk/
+          path: app/build/outputs/apk/
           retention-days: 1
 
   # 버전 관리 작업 (dev 브랜치 머지 시에만)
@@ -124,7 +119,7 @@ jobs:
       contents: write
       actions: write
     outputs:
-      version_code: ${{ steps.version-update.outputs.new_version }}
+      version_code: ${{ vars.VERSION_CODE }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -157,10 +152,24 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           
-          version="${{ needs.test-and-build.outputs.version_name }}"
-          echo "Creating beta tag: $version"
-          git tag -a "v$version" -m "Beta release v$version"
-          git push origin "v$version"
+          # 최신 릴리즈 태그에서 다음 버전 계산
+          latest_tag=$(git tag -l "v*" | grep -v "beta" | sort -V | tail -n 1)
+          if [ -z "$latest_tag" ]; then
+            major=1
+            minor=0
+            patch=0
+          else
+            version=${latest_tag#v}
+            IFS='.' read -r major minor patch <<< "$version"
+            # dev 브랜치는 patch 버전 증가
+            patch=$((patch + 1))
+          fi
+          
+          next_version="$major.$minor.$patch"
+          beta_tag="v$next_version-beta.${{ needs.test-and-build.outputs.timestamp }}"
+          echo "Creating beta tag: $beta_tag"
+          git tag -a "$beta_tag" -m "Beta release $beta_tag"
+          git push origin "$beta_tag"
 
   # main 브랜치 머지 시 릴리즈 태그 생성
   create-release:
@@ -180,14 +189,26 @@ jobs:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Create Release Tag
+        id: create_tag
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           
-          version="${{ needs.test-and-build.outputs.version_name }}"
-          echo "Creating release tag: $version"
-          git tag -a "v$version" -m "Release v$version"
-          git push origin "v$version"
+          # beta 태그들 중 가장 최신 버전 찾기
+          latest_beta=$(git tag -l "v*-beta*" | sort -V | tail -n 1)
+          if [ -z "$latest_beta" ]; then
+            echo "No beta tag found"
+            exit 1
+          fi
+          
+          # beta 태그에서 버전 추출 (beta.timestamp 제거)
+          version=$(echo $latest_beta | sed 's/^v\(.*\)-beta\..*/\1/')
+          release_tag="v$version"
+          
+          echo "Creating release tag: $release_tag"
+          git tag -a "$release_tag" -m "Release $release_tag"
+          git push origin "$release_tag"
+          echo "tag_name=$release_tag" >> $GITHUB_OUTPUT
 
   # 배포 작업
   deploy:
@@ -218,14 +239,20 @@ jobs:
       - name: Generate Release Notes
         id: release_notes
         run: |
-          version="${{ needs.test-and-build.outputs.version_name }}"
-          previous_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          if [[ "${{ github.base_ref }}" == "main" ]]; then
+            # main 브랜치는 최신 릴리즈 태그 사용
+            tag=$(git tag -l "v*" | grep -v "beta" | sort -V | tail -n 1)
+          else
+            # dev 브랜치는 최신 beta 태그 사용
+            tag=$(git tag -l "v*-beta*" | sort -V | tail -n 1)
+          fi
           
           echo "## 변경 사항" > CHANGELOG.md
           echo "" >> CHANGELOG.md
-          echo "버전: $version" >> CHANGELOG.md
+          echo "버전: ${tag#v}" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
           
+          previous_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
           if [ -z "$previous_tag" ]; then
             git log --pretty=format:"- %s" >> CHANGELOG.md
           else
@@ -235,13 +262,12 @@ jobs:
       # GitHub 릴리즈 생성
       - name: Create Release
         uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: |
-            app/build/outputs/apk/**/*.apk
-          tag_name: "v${{ needs.test-and-build.outputs.version_name }}"
-          name: "v${{ needs.test-and-build.outputs.version_name }}"
+          files: app/build/outputs/apk/**/*.apk
+          tag_name: ${{ github.base_ref == 'main' && needs.create-release.outputs.tag_name || github.ref_name }}
+          name: ${{ github.base_ref == 'main' && needs.create-release.outputs.tag_name || github.ref_name }}
           body_path: CHANGELOG.md
           draft: false
-          prerelease: ${{ github.base_ref != 'main' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          prerelease: ${{ github.base_ref != 'main' }} 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,9 +47,9 @@ jobs:
           name: lint-report
           path: app/build/reports/lint-results-debug.html
 
-  # PR 검증용 테스트 및 빌드 작업
-  validate-test-and-build:
-    name: PR Validation - Test and Build
+  # PR 검증용 테스트 작업
+  test-and-build:
+    name: Test and Build
     needs: [validate]
     if: |
       github.event_name == 'pull_request' && 
@@ -75,12 +75,9 @@ jobs:
           name: test-results
           path: app/build/reports/tests/testDebugUnitTest/
 
-      - name: Build Debug APK
-        run: ./gradlew assembleDebug
-
-  # 배포용 테스트 및 빌드 작업
-  test-and-build:
-    name: Test and Build
+  # 배포용 빌드 작업
+  build-for-deploy:
+    name: Build for Deploy
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'pull_request_target' && 
@@ -110,7 +107,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-deploy
           path: app/build/reports/tests/testDebugUnitTest/
 
       - name: Set Timestamp
@@ -139,7 +136,7 @@ jobs:
   version-management:
     name: Version Management
     runs-on: ubuntu-latest
-    needs: [test-and-build]
+    needs: [build-for-deploy]
     if: |
       github.event_name == 'pull_request_target' && 
       github.event.pull_request.merged == true && 
@@ -194,7 +191,7 @@ jobs:
           fi
           
           next_version="$major.$minor.$patch"
-          beta_tag="v$next_version-beta.${{ needs.test-and-build.outputs.timestamp }}"
+          beta_tag="v$next_version-beta.${{ needs.build-for-deploy.outputs.timestamp }}"
           echo "Creating beta tag: $beta_tag"
           git tag -a "$beta_tag" -m "Beta release $beta_tag"
           git push origin "$beta_tag"
@@ -203,7 +200,7 @@ jobs:
   create-release:
     name: Create Release Tag
     runs-on: ubuntu-latest
-    needs: [test-and-build]
+    needs: [build-for-deploy]
     if: |
       github.event_name == 'pull_request_target' && 
       github.event.pull_request.merged == true && 
@@ -241,7 +238,7 @@ jobs:
   deploy:
     name: Deploy APK
     runs-on: ubuntu-latest
-    needs: [test-and-build]
+    needs: [build-for-deploy]
     if: |
       (github.event_name == 'pull_request_target' && 
        github.event.pull_request.merged == true) ||

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,12 +47,42 @@ jobs:
           name: lint-report
           path: app/build/reports/lint-results-debug.html
 
-  # 테스트 및 빌드 작업 (통합)
+  # PR 검증용 테스트 및 빌드 작업
+  validate-test-and-build:
+    name: PR Validation - Test and Build
+    needs: [validate]
+    if: |
+      github.event_name == 'pull_request' && 
+      !github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Run Unit Tests
+        run: ./gradlew testDebugUnitTest
+        
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: app/build/reports/tests/testDebugUnitTest/
+
+      - name: Build Debug APK
+        run: ./gradlew assembleDebug
+
+  # 배포용 테스트 및 빌드 작업
   test-and-build:
     name: Test and Build
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'pull_request' ||
       (github.event_name == 'pull_request_target' && 
        github.event.pull_request.merged == true) ||
       (github.event_name == 'push' && 
@@ -99,9 +129,6 @@ jobs:
           fi
 
       - name: Upload Build Artifact
-        if: |
-          github.event_name == 'pull_request_target' && 
-          github.event.pull_request.merged == true
         uses: actions/upload-artifact@v4
         with:
           name: build-output

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main", "dev" ]
   pull_request_target:
     types: [closed]
-    branches: ["dev"]
+    branches: ["dev", "main"]
   push:
     branches: ["main"]
     tags:
@@ -50,15 +50,15 @@ jobs:
   # 테스트 및 빌드 작업 (통합)
   test-and-build:
     name: Test and Build
-    if: |
-      (github.event_name == 'pull_request' && !github.event.pull_request.merged) ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true && github.base_ref == 'dev') ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     needs: [validate]
+    if: |
+      (github.event_name == 'pull_request' && !github.event.pull_request.merged) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
     outputs:
       apk_path: ${{ steps.build-apk.outputs.apk_path }}
       build_type: ${{ steps.set-build-type.outputs.build_type }}
+      version_name: ${{ steps.set-version.outputs.version_name }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,44 +82,51 @@ jobs:
           name: test-results
           path: app/build/reports/tests/testDebugUnitTest/
 
-      # 빌드 타입 설정
-      - name: Set Build Type
-        id: set-build-type
+      # 버전 정보 설정
+      - name: Set Version Info
+        id: set-version
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+          if [[ "${{ github.base_ref }}" == "main" ]]; then
+            version_name="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
+            echo "version_name=$version_name" >> $GITHUB_OUTPUT
             echo "build_type=release" >> $GITHUB_OUTPUT
           else
+            timestamp=$(date +%Y%m%d%H%M%S)
+            version_name="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-beta.$timestamp"
+            echo "version_name=$version_name" >> $GITHUB_OUTPUT
             echo "build_type=debug" >> $GITHUB_OUTPUT
           fi
 
-      # APK 빌드 (PR 검증 또는 배포용)
+      # APK 빌드
       - name: Build APK
         id: build-apk
         run: |
-          if [[ "${{ steps.set-build-type.outputs.build_type }}" == "release" ]]; then
+          if [[ "${{ steps.set-version.outputs.build_type }}" == "release" ]]; then
             ./gradlew assembleRelease
             APK_DIR="app/build/outputs/apk/release"
-            APK_PATTERN="*-release-unsigned.apk"
+            APK_PATTERN="app-release-unsigned.apk"
+            TARGET_APK="toy-practice-androidtest-${{ steps.set-version.outputs.version_name }}-release.apk"
           else
             ./gradlew assembleDebug
             APK_DIR="app/build/outputs/apk/debug"
-            APK_PATTERN="*-debug.apk"
+            APK_PATTERN="app-debug.apk"
+            TARGET_APK="toy-practice-androidtest-${{ steps.set-version.outputs.version_name }}-debug.apk"
           fi
           
-          # APK 파일 찾기
-          APK_FILE=$(find "$APK_DIR" -name "$APK_PATTERN" -type f)
-          if [ ! -z "$APK_FILE" ]; then
-            echo "APK built successfully at: $APK_FILE"
-            echo "apk_path=$APK_FILE" >> $GITHUB_OUTPUT
+          # APK 파일 이름 변경
+          if [ -f "$APK_DIR/$APK_PATTERN" ]; then
+            mv "$APK_DIR/$APK_PATTERN" "$APK_DIR/$TARGET_APK"
+            echo "apk_path=$APK_DIR/$TARGET_APK" >> $GITHUB_OUTPUT
           else
-            echo "Error: APK not found matching pattern: $APK_PATTERN"
-            echo "Listing contents of $APK_DIR/:"
-            ls -la "$APK_DIR"
+            echo "Error: APK not found at $APK_DIR/$APK_PATTERN"
             exit 1
           fi
 
       # 빌드 결과물 저장
       - name: Upload Build Artifact
+        if: |
+          github.event_name == 'pull_request_target' && 
+          github.event.pull_request.merged == true
         uses: actions/upload-artifact@v4
         with:
           name: build-output
@@ -128,14 +135,14 @@ jobs:
             version.properties
           retention-days: 1
 
-  # 버전 관리 작업 (릴리즈 시에만)
+  # 버전 관리 작업 (dev 브랜치 머지 시에만)
   version-management:
     name: Version Management
+    runs-on: ubuntu-latest
     if: |
       github.event_name == 'pull_request_target' && 
       github.event.pull_request.merged == true && 
       github.base_ref == 'dev'
-    runs-on: ubuntu-latest
     needs: [test-and-build]
     permissions:
       contents: write
@@ -169,49 +176,53 @@ jobs:
             console.log(`Version Code updated: ${currentVersion} → ${newVersion}`);
             core.setOutput('new_version', newVersion.toString());
 
-      - name: Create Version Tag
+      - name: Create Beta Tag
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           
-          timestamp=$(date +%Y%m%d%H%M%S)
-          latest_tag=$(git tag -l "v*" | grep -v "beta" | sort -V | tail -n 1)
+          version="${{ needs.test-and-build.outputs.version_name }}"
+          echo "Creating beta tag: $version"
+          git tag -a "v$version" -m "Beta release v$version"
+          git push origin "v$version"
+
+  # main 브랜치 머지 시 릴리즈 태그 생성
+  create-release:
+    name: Create Release Tag
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request_target' && 
+      github.event.pull_request.merged == true && 
+      github.base_ref == 'main'
+    needs: [test-and-build]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Create Release Tag
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
           
-          if [ -z "$latest_tag" ]; then
-            base_version="1.0.0"
-          else
-            base_version=$(echo $latest_tag | sed 's/^v//')
-            IFS='.' read -r major minor patch <<< "$base_version"
-            
-            case "${{ github.head_ref }}" in
-              major/*)
-                base_version="$((major + 1)).0.0"
-                ;;
-              feat/*)
-                base_version="$major.$((minor + 1)).0"
-                ;;
-              fix/* | *)
-                base_version="$major.$minor.$((patch + 1))"
-                ;;
-            esac
-          fi
-          
-          new_version="v${base_version}-beta.$timestamp"
-          echo "Creating beta tag: $new_version"
-          git tag -a "$new_version" -m "Beta release $new_version"
-          git push origin "$new_version"
+          version="${{ needs.test-and-build.outputs.version_name }}"
+          echo "Creating release tag: $version"
+          git tag -a "v$version" -m "Release v$version"
+          git push origin "v$version"
 
   # 배포 작업
   deploy:
     name: Deploy APK
-    needs: [test-and-build, version-management]
+    runs-on: ubuntu-latest
+    needs: [test-and-build]
     if: |
       (github.event_name == 'pull_request_target' && 
-       github.event.pull_request.merged == true && 
-       github.base_ref == 'dev') ||
+       github.event.pull_request.merged == true) ||
       (github.event_name == 'push' && 
        startsWith(github.ref, 'refs/tags/v'))
-    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
@@ -227,12 +238,11 @@ jobs:
           name: build-output
           path: .
 
-      # 릴리즈 노트 생성 (태그 푸시 시에만)
+      # 릴리즈 노트 생성
       - name: Generate Release Notes
-        if: startsWith(github.ref, 'refs/tags/v')
         id: release_notes
         run: |
-          version=$(git describe --tags --abbrev=0)
+          version="${{ needs.test-and-build.outputs.version_name }}"
           previous_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
           
           echo "## 변경 사항" > CHANGELOG.md
@@ -246,17 +256,16 @@ jobs:
             git log --pretty=format:"- %s" ${previous_tag}..HEAD >> CHANGELOG.md
           fi
 
-      # GitHub 릴리즈 생성 (태그 푸시 시에만)
+      # GitHub 릴리즈 생성
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            app/build/outputs/apk/release/*-release-unsigned.apk
-          name: "v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
+            app/build/outputs/apk/**/*.apk
+          tag_name: "v${{ needs.test-and-build.outputs.version_name }}"
+          name: "v${{ needs.test-and-build.outputs.version_name }}"
           body_path: CHANGELOG.md
           draft: false
-          prerelease: false
-          generate_release_notes: false
+          prerelease: ${{ github.base_ref != 'main' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,8 +6,6 @@ on:
   pull_request_target:
     types: [closed]
     branches: ["dev", "main"]
-  push:
-    branches: ["main"]
 
 # PR이 머지되기 전에 모든 체크가 통과되어야 함을 명시
 concurrency:
@@ -83,6 +81,7 @@ jobs:
     outputs:
       build_type: ${{ github.base_ref == 'main' && 'release' || 'debug' }}
       timestamp: ${{ steps.set-timestamp.outputs.value }}
+      artifact_name: ${{ steps.set-artifact-name.outputs.value }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -110,6 +109,15 @@ jobs:
         id: set-timestamp
         run: echo "value=$(date +%Y%m%d%H%M%S)" >> $GITHUB_OUTPUT
 
+      - name: Set Artifact Name
+        id: set-artifact-name
+        run: |
+          if [[ "${{ github.base_ref }}" == "main" ]]; then
+            echo "value=release-build" >> $GITHUB_OUTPUT
+          else
+            echo "value=beta-build" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build APK
         env:
           VERSION_CODE: ${{ vars.VERSION_CODE }}
@@ -124,7 +132,7 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-output
+          name: ${{ steps.set-artifact-name.outputs.value }}
           path: |
             app/build/outputs/apk/**/*.apk
             app/build/outputs/apk/**/output-metadata.json
@@ -199,7 +207,7 @@ jobs:
           git push origin "$beta_tag"
 
   # main 브랜치 머지 시 릴리즈 태그 생성
-  create-release:
+  create-release-tag:
     name: Create Release Tag
     runs-on: ubuntu-latest
     needs: [build-for-deploy]
@@ -238,15 +246,15 @@ jobs:
           git tag -a "$release_tag" -m "Release $release_tag"
           git push origin "$release_tag"
 
-  # 배포 작업
-  deploy:
-    name: Deploy APK
+  # 베타 릴리즈 생성 (dev 브랜치 머지 시)
+  create-beta-release:
+    name: Create Beta Release
     runs-on: ubuntu-latest
-    needs: [build-for-deploy, version-management, create-release]
+    needs: [build-for-deploy, version-management]
     if: |
       github.event_name == 'pull_request_target' && 
-      github.event.pull_request.merged == true &&
-      (needs.version-management.result == 'success' || needs.create-release.result == 'success')
+      github.event.pull_request.merged == true && 
+      github.base_ref == 'dev'
     permissions:
       contents: write
     steps:
@@ -259,21 +267,66 @@ jobs:
       - name: Download Build Artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-output
+          name: ${{ needs.build-for-deploy.outputs.artifact_name }}
+          path: .
+
+      - name: Generate Beta Release Notes
+        run: |
+          echo "## 베타 릴리즈 노트" > CHANGELOG.md
+          echo "" >> CHANGELOG.md
+          echo "버전: ${needs.version-management.outputs.beta_tag#v}" >> CHANGELOG.md
+          echo "" >> CHANGELOG.md
+          
+          previous_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          if [ -z "$previous_tag" ]; then
+            git log --pretty=format:"- %s" >> CHANGELOG.md
+          else
+            git log --pretty=format:"- %s" ${previous_tag}..HEAD >> CHANGELOG.md
+          fi
+
+      - name: Create Beta Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        with:
+          files: |
+            **/*.apk
+            **/output-metadata.json
+          tag_name: ${{ needs.version-management.outputs.beta_tag }}
+          name: "Beta Release ${{ needs.version-management.outputs.beta_tag }}"
+          body_path: CHANGELOG.md
+          draft: false
+          prerelease: true
+
+  # 정식 릴리즈 생성 (main 브랜치 머지 시)
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: [build-for-deploy, create-release-tag]
+    if: |
+      github.event_name == 'pull_request_target' && 
+      github.event.pull_request.merged == true && 
+      github.base_ref == 'main'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          token: ${{ secrets.ADMIN_TOKEN }}
+        
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-for-deploy.outputs.artifact_name }}
           path: .
 
       - name: Generate Release Notes
-        id: release_notes
         run: |
-          if [[ "${{ github.base_ref }}" == "main" ]]; then
-            tag="${{ needs.create-release.outputs.release_tag }}"
-          else
-            tag="${{ needs.version-management.outputs.beta_tag }}"
-          fi
-          
-          echo "## 변경 사항" > CHANGELOG.md
+          echo "## 릴리즈 노트" > CHANGELOG.md
           echo "" >> CHANGELOG.md
-          echo "버전: ${tag#v}" >> CHANGELOG.md
+          echo "버전: ${needs.create-release-tag.outputs.release_tag#v}" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
           
           previous_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
@@ -291,8 +344,8 @@ jobs:
           files: |
             **/*.apk
             **/output-metadata.json
-          tag_name: ${{ github.base_ref == 'main' && needs.create-release.outputs.release_tag || needs.version-management.outputs.beta_tag }}
-          name: ${{ github.base_ref == 'main' && needs.create-release.outputs.release_tag || needs.version-management.outputs.beta_tag }}
+          tag_name: ${{ needs.create-release-tag.outputs.release_tag }}
+          name: "Release ${{ needs.create-release-tag.outputs.release_tag }}"
           body_path: CHANGELOG.md
           draft: false
-          prerelease: ${{ github.base_ref != 'main' }} 
+          prerelease: false 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -260,7 +260,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ needs.version-management.outputs.beta_tag }}
           fetch-depth: 0
           token: ${{ secrets.ADMIN_TOKEN }}
         
@@ -268,7 +268,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build-for-deploy.outputs.artifact_name }}
-          path: .
+          path: artifacts
 
       - name: Generate Beta Release Notes
         run: |
@@ -290,8 +290,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         with:
           files: |
-            **/*.apk
-            **/output-metadata.json
+            artifacts/**/*.apk
+            artifacts/**/output-metadata.json
           tag_name: ${{ needs.version-management.outputs.beta_tag }}
           name: "Beta Release ${{ needs.version-management.outputs.beta_tag }}"
           body_path: CHANGELOG.md
@@ -312,7 +312,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ needs.create-release-tag.outputs.release_tag }}
           fetch-depth: 0
           token: ${{ secrets.ADMIN_TOKEN }}
         
@@ -320,7 +320,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build-for-deploy.outputs.artifact_name }}
-          path: .
+          path: artifacts
 
       - name: Generate Release Notes
         run: |
@@ -342,8 +342,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         with:
           files: |
-            **/*.apk
-            **/output-metadata.json
+            artifacts/**/*.apk
+            artifacts/**/output-metadata.json
           tag_name: ${{ needs.create-release-tag.outputs.release_tag }}
           name: "Release ${{ needs.create-release-tag.outputs.release_tag }}"
           body_path: CHANGELOG.md

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -82,66 +82,21 @@ jobs:
           name: test-results
           path: app/build/reports/tests/testDebugUnitTest/
 
-      # 버전 정보 설정
-      - name: Set Version Info
-        id: set-version
-        run: |
-          # 최신 태그에서 버전 정보 추출
-          latest_tag=$(git tag -l "v*" | grep -v "beta" | sort -V | tail -n 1)
-          if [ -z "$latest_tag" ]; then
-            major=1
-            minor=0
-            patch=0
-          else
-            version=${latest_tag#v}  # v 제거
-            IFS='.' read -r major minor patch <<< "$version"
-          fi
-          
-          if [[ "${{ github.base_ref }}" == "main" ]]; then
-            # main 브랜치는 현재 태그 버전 사용
-            version_name="$major.$minor.$patch"
-            echo "version_name=$version_name" >> $GITHUB_OUTPUT
-            echo "build_type=release" >> $GITHUB_OUTPUT
-          else
-            # dev 브랜치는 beta 태그 추가
-            timestamp=$(date +%Y%m%d%H%M%S)
-            version_name="$major.$minor.$patch-beta.$timestamp"
-            echo "version_name=$version_name" >> $GITHUB_OUTPUT
-            echo "build_type=debug" >> $GITHUB_OUTPUT
-          fi
-          
-          # version.properties 파일 생성
-          echo "VERSION_CODE=${{ vars.VERSION_CODE }}" > version.properties
-          echo "VERSION_MAJOR=$major" >> version.properties
-          echo "VERSION_MINOR=$minor" >> version.properties
-          echo "VERSION_PATCH=$patch" >> version.properties
-          if [[ "${{ github.base_ref }}" == "main" ]]; then
-            echo "IS_BETA=false" >> version.properties
-          else
-            echo "IS_BETA=true" >> version.properties
-            echo "TIMESTAMP=$timestamp" >> version.properties
-          fi
+      # 타임스탬프 생성
+      - name: Generate Timestamp
+        id: timestamp
+        run: echo "timestamp=$(date +%Y%m%d%H%M%S)" >> $GITHUB_OUTPUT
 
       # APK 빌드
       - name: Build APK
-        id: build-apk
+        env:
+          VERSION_CODE: ${{ vars.VERSION_CODE }}
+          BUILD_TIMESTAMP: ${{ steps.timestamp.outputs.timestamp }}
         run: |
-          if [[ "${{ steps.set-version.outputs.build_type }}" == "release" ]]; then
-            ./gradlew assembleRelease
-            APK_DIR="app/build/outputs/apk/release"
+          if [[ "${{ github.base_ref }}" == "main" ]]; then
+            ./gradlew assembleRelease -Prelease
           else
             ./gradlew assembleDebug
-            APK_DIR="app/build/outputs/apk/debug"
-          fi
-          
-          # APK 파일 찾기
-          APK_FILE=$(find "$APK_DIR" -name "*.apk" -type f)
-          if [ ! -z "$APK_FILE" ]; then
-            echo "APK built successfully at: $APK_FILE"
-            echo "apk_path=$APK_FILE" >> $GITHUB_OUTPUT
-          else
-            echo "Error: APK not found in $APK_DIR"
-            exit 1
           fi
 
       # 빌드 결과물 저장
@@ -154,7 +109,6 @@ jobs:
           name: build-output
           path: |
             app/build/outputs/apk/
-            version.properties
           retention-days: 1
 
   # 버전 관리 작업 (dev 브랜치 머지 시에만)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -104,21 +104,18 @@ jobs:
           if [[ "${{ steps.set-version.outputs.build_type }}" == "release" ]]; then
             ./gradlew assembleRelease
             APK_DIR="app/build/outputs/apk/release"
-            APK_PATTERN="app-release-unsigned.apk"
-            TARGET_APK="toy-practice-androidtest-${{ steps.set-version.outputs.version_name }}-release.apk"
           else
             ./gradlew assembleDebug
             APK_DIR="app/build/outputs/apk/debug"
-            APK_PATTERN="app-debug.apk"
-            TARGET_APK="toy-practice-androidtest-${{ steps.set-version.outputs.version_name }}-debug.apk"
           fi
           
-          # APK 파일 이름 변경
-          if [ -f "$APK_DIR/$APK_PATTERN" ]; then
-            mv "$APK_DIR/$APK_PATTERN" "$APK_DIR/$TARGET_APK"
-            echo "apk_path=$APK_DIR/$TARGET_APK" >> $GITHUB_OUTPUT
+          # APK 파일 찾기
+          APK_FILE=$(find "$APK_DIR" -name "*.apk" -type f)
+          if [ ! -z "$APK_FILE" ]; then
+            echo "APK built successfully at: $APK_FILE"
+            echo "apk_path=$APK_FILE" >> $GITHUB_OUTPUT
           else
-            echo "Error: APK not found at $APK_DIR/$APK_PATTERN"
+            echo "Error: APK not found in $APK_DIR"
             exit 1
           fi
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,10 +51,12 @@ jobs:
   test-and-build:
     name: Test and Build
     runs-on: ubuntu-latest
-    needs: [validate]
     if: |
-      (github.event_name == 'pull_request' && !github.event.pull_request.merged) ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request_target' && 
+       github.event.pull_request.merged == true) ||
+      (github.event_name == 'push' && 
+       startsWith(github.ref, 'refs/tags/v'))
     outputs:
       build_type: ${{ github.base_ref == 'main' && 'release' || 'debug' }}
       timestamp: ${{ steps.set-timestamp.outputs.value }}
@@ -97,9 +99,6 @@ jobs:
           fi
 
       - name: Upload Build Artifact
-        if: |
-          github.event_name == 'pull_request_target' && 
-          github.event.pull_request.merged == true
         uses: actions/upload-artifact@v4
         with:
           name: build-output
@@ -110,11 +109,11 @@ jobs:
   version-management:
     name: Version Management
     runs-on: ubuntu-latest
+    needs: [test-and-build]
     if: |
       github.event_name == 'pull_request_target' && 
       github.event.pull_request.merged == true && 
       github.base_ref == 'dev'
-    needs: [test-and-build]
     permissions:
       contents: write
       actions: write
@@ -125,6 +124,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+          token: ${{ secrets.ADMIN_TOKEN }}
 
       - name: Update Version Code
         id: version-update
@@ -152,7 +152,6 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           
-          # 최신 릴리즈 태그에서 다음 버전 계산
           latest_tag=$(git tag -l "v*" | grep -v "beta" | sort -V | tail -n 1)
           if [ -z "$latest_tag" ]; then
             major=1
@@ -161,7 +160,6 @@ jobs:
           else
             version=${latest_tag#v}
             IFS='.' read -r major minor patch <<< "$version"
-            # dev 브랜치는 patch 버전 증가
             patch=$((patch + 1))
           fi
           
@@ -175,11 +173,11 @@ jobs:
   create-release:
     name: Create Release Tag
     runs-on: ubuntu-latest
+    needs: [test-and-build]
     if: |
       github.event_name == 'pull_request_target' && 
       github.event.pull_request.merged == true && 
       github.base_ref == 'main'
-    needs: [test-and-build]
     permissions:
       contents: write
     steps:
@@ -187,6 +185,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+          token: ${{ secrets.ADMIN_TOKEN }}
 
       - name: Create Release Tag
         id: create_tag
@@ -194,14 +193,12 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           
-          # beta 태그들 중 가장 최신 버전 찾기
           latest_beta=$(git tag -l "v*-beta*" | sort -V | tail -n 1)
           if [ -z "$latest_beta" ]; then
             echo "No beta tag found"
             exit 1
           fi
           
-          # beta 태그에서 버전 추출 (beta.timestamp 제거)
           version=$(echo $latest_beta | sed 's/^v\(.*\)-beta\..*/\1/')
           release_tag="v$version"
           
@@ -227,23 +224,20 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
+          token: ${{ secrets.ADMIN_TOKEN }}
         
-      # 빌드 결과물 다운로드
       - name: Download Build Artifact
         uses: actions/download-artifact@v4
         with:
           name: build-output
           path: .
 
-      # 릴리즈 노트 생성
       - name: Generate Release Notes
         id: release_notes
         run: |
           if [[ "${{ github.base_ref }}" == "main" ]]; then
-            # main 브랜치는 최신 릴리즈 태그 사용
             tag=$(git tag -l "v*" | grep -v "beta" | sort -V | tail -n 1)
           else
-            # dev 브랜치는 최신 beta 태그 사용
             tag=$(git tag -l "v*-beta*" | sort -V | tail -n 1)
           fi
           
@@ -259,13 +253,12 @@ jobs:
             git log --pretty=format:"- %s" ${previous_tag}..HEAD >> CHANGELOG.md
           fi
 
-      # GitHub 릴리즈 생성
       - name: Create Release
         uses: softprops/action-gh-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         with:
-          files: app/build/outputs/apk/**/*.apk
+          files: "**/*.apk"
           tag_name: ${{ github.base_ref == 'main' && needs.create-release.outputs.tag_name || github.ref_name }}
           name: ${{ github.base_ref == 'main' && needs.create-release.outputs.tag_name || github.ref_name }}
           body_path: CHANGELOG.md

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,8 +8,6 @@ on:
     branches: ["dev", "main"]
   push:
     branches: ["main"]
-    tags:
-      - 'v*'
 
 # PR이 머지되기 전에 모든 체크가 통과되어야 함을 명시
 concurrency:
@@ -80,10 +78,8 @@ jobs:
     name: Build for Deploy
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request_target' && 
-       github.event.pull_request.merged == true) ||
-      (github.event_name == 'push' && 
-       startsWith(github.ref, 'refs/tags/v'))
+      github.event_name == 'pull_request_target' && 
+      github.event.pull_request.merged == true
     outputs:
       build_type: ${{ github.base_ref == 'main' && 'release' || 'debug' }}
       timestamp: ${{ steps.set-timestamp.outputs.value }}
@@ -129,7 +125,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-output
-          path: app/build/outputs/apk/
+          path: |
+            app/build/outputs/apk/**/*.apk
+            app/build/outputs/apk/**/output-metadata.json
           retention-days: 1
 
   # 버전 관리 작업 (dev 브랜치 머지 시에만)
@@ -146,6 +144,7 @@ jobs:
       actions: write
     outputs:
       version_code: ${{ vars.VERSION_CODE }}
+      beta_tag: ${{ steps.create-beta-tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -175,6 +174,7 @@ jobs:
             core.setOutput('new_version', newVersion.toString());
 
       - name: Create Beta Tag
+        id: create-beta-tag
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
@@ -192,6 +192,8 @@ jobs:
           
           next_version="$major.$minor.$patch"
           beta_tag="v$next_version-beta.${{ needs.build-for-deploy.outputs.timestamp }}"
+          echo "tag=$beta_tag" >> $GITHUB_OUTPUT
+          
           echo "Creating beta tag: $beta_tag"
           git tag -a "$beta_tag" -m "Beta release $beta_tag"
           git push origin "$beta_tag"
@@ -207,6 +209,8 @@ jobs:
       github.base_ref == 'main'
     permissions:
       contents: write
+    outputs:
+      release_tag: ${{ steps.create-release-tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -215,7 +219,7 @@ jobs:
           token: ${{ secrets.ADMIN_TOKEN }}
 
       - name: Create Release Tag
-        id: create_tag
+        id: create-release-tag
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
@@ -228,22 +232,21 @@ jobs:
           
           version=$(echo $latest_beta | sed 's/^v\(.*\)-beta\..*/\1/')
           release_tag="v$version"
+          echo "tag=$release_tag" >> $GITHUB_OUTPUT
           
           echo "Creating release tag: $release_tag"
           git tag -a "$release_tag" -m "Release $release_tag"
           git push origin "$release_tag"
-          echo "tag_name=$release_tag" >> $GITHUB_OUTPUT
 
   # 배포 작업
   deploy:
     name: Deploy APK
     runs-on: ubuntu-latest
-    needs: [build-for-deploy]
+    needs: [build-for-deploy, version-management, create-release]
     if: |
-      (github.event_name == 'pull_request_target' && 
-       github.event.pull_request.merged == true) ||
-      (github.event_name == 'push' && 
-       startsWith(github.ref, 'refs/tags/v'))
+      github.event_name == 'pull_request_target' && 
+      github.event.pull_request.merged == true &&
+      (needs.version-management.result == 'success' || needs.create-release.result == 'success')
     permissions:
       contents: write
     steps:
@@ -263,9 +266,9 @@ jobs:
         id: release_notes
         run: |
           if [[ "${{ github.base_ref }}" == "main" ]]; then
-            tag=$(git tag -l "v*" | grep -v "beta" | sort -V | tail -n 1)
+            tag="${{ needs.create-release.outputs.release_tag }}"
           else
-            tag=$(git tag -l "v*-beta*" | sort -V | tail -n 1)
+            tag="${{ needs.version-management.outputs.beta_tag }}"
           fi
           
           echo "## 변경 사항" > CHANGELOG.md
@@ -285,9 +288,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         with:
-          files: "**/*.apk"
-          tag_name: ${{ github.base_ref == 'main' && needs.create-release.outputs.tag_name || github.ref_name }}
-          name: ${{ github.base_ref == 'main' && needs.create-release.outputs.tag_name || github.ref_name }}
+          files: |
+            **/*.apk
+            **/output-metadata.json
+          tag_name: ${{ github.base_ref == 'main' && needs.create-release.outputs.release_tag || needs.version-management.outputs.beta_tag }}
+          name: ${{ github.base_ref == 'main' && needs.create-release.outputs.release_tag || needs.version-management.outputs.beta_tag }}
           body_path: CHANGELOG.md
           draft: false
           prerelease: ${{ github.base_ref != 'main' }} 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -86,15 +86,40 @@ jobs:
       - name: Set Version Info
         id: set-version
         run: |
+          # 최신 태그에서 버전 정보 추출
+          latest_tag=$(git tag -l "v*" | grep -v "beta" | sort -V | tail -n 1)
+          if [ -z "$latest_tag" ]; then
+            major=1
+            minor=0
+            patch=0
+          else
+            version=${latest_tag#v}  # v 제거
+            IFS='.' read -r major minor patch <<< "$version"
+          fi
+          
           if [[ "${{ github.base_ref }}" == "main" ]]; then
-            version_name="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
+            # main 브랜치는 현재 태그 버전 사용
+            version_name="$major.$minor.$patch"
             echo "version_name=$version_name" >> $GITHUB_OUTPUT
             echo "build_type=release" >> $GITHUB_OUTPUT
           else
+            # dev 브랜치는 beta 태그 추가
             timestamp=$(date +%Y%m%d%H%M%S)
-            version_name="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-beta.$timestamp"
+            version_name="$major.$minor.$patch-beta.$timestamp"
             echo "version_name=$version_name" >> $GITHUB_OUTPUT
             echo "build_type=debug" >> $GITHUB_OUTPUT
+          fi
+          
+          # version.properties 파일 생성
+          echo "VERSION_CODE=${{ vars.VERSION_CODE }}" > version.properties
+          echo "VERSION_MAJOR=$major" >> version.properties
+          echo "VERSION_MINOR=$minor" >> version.properties
+          echo "VERSION_PATCH=$patch" >> version.properties
+          if [[ "${{ github.base_ref }}" == "main" ]]; then
+            echo "IS_BETA=false" >> version.properties
+          else
+            echo "IS_BETA=true" >> version.properties
+            echo "TIMESTAMP=$timestamp" >> version.properties
           fi
 
       # APK 빌드


### PR DESCRIPTION
## 변경사항 1. 태그/릴리즈 생성 순서 보장 - Beta: build-for-deploy -> version-management -> create-beta-release - Release: build-for-deploy -> create-release-tag -> create-release 2. 태그 이벤트로 인한 중복 실행 방지 - on.push 트리거 제거 3. 아티팩트 관리 개선 - 빌드 아티팩트 이름을 beta-build와 release-build로 구분 - 아티팩트 이름을 job output으로 전달 4. 릴리즈 프로세스 분리 - 베타/정식 릴리즈 생성 job 분리 - 릴리즈 노트 템플릿 분리