### PR TITLE
fix: 베타/릴리즈 노트 생성 스크립트 변수 치환 문법 수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -272,9 +272,12 @@ jobs:
 
       - name: Generate Beta Release Notes
         run: |
+          BETA_TAG="${{ needs.version-management.outputs.beta_tag }}"
+          VERSION="${BETA_TAG#v}"
+          
           echo "## 베타 릴리즈 노트" > CHANGELOG.md
           echo "" >> CHANGELOG.md
-          echo "버전: ${needs.version-management.outputs.beta_tag#v}" >> CHANGELOG.md
+          echo "버전: $VERSION" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
           
           previous_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
@@ -324,9 +327,12 @@ jobs:
 
       - name: Generate Release Notes
         run: |
+          RELEASE_TAG="${{ needs.create-release-tag.outputs.release_tag }}"
+          VERSION="${RELEASE_TAG#v}"
+          
           echo "## 릴리즈 노트" > CHANGELOG.md
           echo "" >> CHANGELOG.md
-          echo "버전: ${needs.create-release-tag.outputs.release_tag#v}" >> CHANGELOG.md
+          echo "버전: $VERSION" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
           
           previous_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")


### PR DESCRIPTION
## 수정사항\n\n### 버그 수정\n- 베타/릴리즈 노트 생성 시 버전 정보 변수 치환 오류 수정\n- 변수를 임시 변수에 저장하여 사용하도록 변경\n\n### 변경 내용\n- 변수 치환 문법 개선\n- 버전 추출 로직을 별도 변수로 분리