### PR TITLE
feat: 릴리즈 타임스탬프를 KST로 변경

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -107,6 +107,8 @@ jobs:
 
       - name: Set Timestamp
         id: set-timestamp
+        env:
+          TZ: 'Asia/Seoul'
         run: echo "value=$(date +%Y%m%d%H%M%S)" >> $GITHUB_OUTPUT
 
       - name: Set Artifact Name

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -272,9 +272,12 @@ jobs:
 
       - name: Generate Beta Release Notes
         run: |
+          BETA_TAG="${{ needs.version-management.outputs.beta_tag }}"
+          VERSION="${BETA_TAG#v}"
+          
           echo "## 베타 릴리즈 노트" > CHANGELOG.md
           echo "" >> CHANGELOG.md
-          echo "버전: ${needs.version-management.outputs.beta_tag#v}" >> CHANGELOG.md
+          echo "버전: $VERSION" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
           
           previous_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
@@ -324,9 +327,12 @@ jobs:
 
       - name: Generate Release Notes
         run: |
+          RELEASE_TAG="${{ needs.create-release-tag.outputs.release_tag }}"
+          VERSION="${RELEASE_TAG#v}"
+          
           echo "## 릴리즈 노트" > CHANGELOG.md
           echo "" >> CHANGELOG.md
-          echo "버전: ${needs.create-release-tag.outputs.release_tag#v}" >> CHANGELOG.md
+          echo "버전: $VERSION" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
           
           previous_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")


### PR DESCRIPTION
## 변경사항\n\n### 기능 추가\n- 릴리즈 타임스탬프를 KST(한국 표준시)로 변경\n- GitHub Actions 기본 시간대(UTC)를 KST로 변경하여 타임스탬프 생성\n\n### 상세 내용\n- `TZ` 환경변수를 'Asia/Seoul'로 설정\n- 베타 릴리즈 태그에 KST 기준 타임스탬프가 포함됨