### PR TITLE
fix: APK 버전명을 베타 릴리즈 태그와 동일하게 설정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -124,6 +124,7 @@ jobs:
         env:
           VERSION_CODE: ${{ vars.VERSION_CODE }}
           BUILD_TIMESTAMP: ${{ steps.set-timestamp.outputs.value }}
+          BETA_VERSION: ${{ needs.version-management.outputs.version }}
         run: |
           if [[ "${{ github.base_ref }}" == "main" ]]; then
             ./gradlew assembleRelease -Prelease

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,16 @@ fun loadConfigProperties(buildType: String): Properties {
 
 fun getVersionFromTag(): Triple<Int, Int, Int> {
     try {
+        // CI/CD에서 생성한 베타 태그가 있는 경우 해당 버전 사용
+        System.getenv("BETA_VERSION")?.let { betaVersion ->
+            val version = betaVersion.split(".")
+            return Triple(
+                version.getOrNull(0)?.toIntOrNull() ?: 1,
+                version.getOrNull(1)?.toIntOrNull() ?: 0,
+                version.getOrNull(2)?.toIntOrNull() ?: 0,
+            )
+        }
+
         val stdout = ByteArrayOutputStream()
         exec {
             commandLine("git", "describe", "--tags", "--abbrev=0")


### PR DESCRIPTION
## 변경 사항
- CI/CD에서 계산한 베타 버전을 Gradle 빌드 스크립트에 전달하여 APK 버전명 설정
- 베타 릴리즈 태그와 APK 버전명이 일치하도록 수정

## 테스트 방법
1. dev 브랜치에 PR 머지
2. 베타 릴리즈가 생성되는지 확인
3. 생성된 APK의 버전명이 베타 릴리즈 태그와 일치하는지 확인 