### PR TITLE
fix: 베타 릴리즈 관리 개선 - 이전 릴리즈 삭제 및 노트 누적 기능 추가

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -327,6 +327,48 @@ jobs:
           name: ${{ needs.build-for-deploy.outputs.artifact_name }}
           path: artifacts
 
+      - name: Get Previous Beta Release Notes
+        id: get-previous-notes
+        if: needs.version-management.outputs.has_previous_beta == 'true'
+        run: |
+          previous_beta="${{ needs.version-management.outputs.previous_beta }}"
+          echo "이전 베타 릴리즈 노트 가져오는 중: $previous_beta"
+          
+          # GitHub API를 통해 이전 릴리즈 노트 가져오기
+          previous_notes=$(curl -s -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/tags/$previous_beta" \
+            | jq -r '.body // empty')
+          
+          if [ ! -z "$previous_notes" ] && [ "$previous_notes" != "null" ]; then
+            # 변경 사항 부분만 추출 (헤더 제외)
+            changes=$(echo "$previous_notes" | sed -n '/^- /p' | head -20)
+            echo "previous_changes<<EOF" >> $GITHUB_OUTPUT
+            echo "$changes" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Delete Previous Beta Release
+        if: needs.version-management.outputs.has_previous_beta == 'true'
+        run: |
+          previous_beta="${{ needs.version-management.outputs.previous_beta }}"
+          echo "이전 베타 릴리즈 삭제 중: $previous_beta"
+          
+          # GitHub API를 통해 이전 릴리즈 삭제
+          release_id=$(curl -s -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/tags/$previous_beta" \
+            | jq -r '.id // empty')
+          
+          if [ ! -z "$release_id" ] && [ "$release_id" != "null" ]; then
+            curl -X DELETE -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/$release_id"
+            echo "이전 베타 릴리즈 삭제 완료: $release_id"
+          else
+            echo "이전 베타 릴리즈를 찾을 수 없음"
+          fi
+
       - name: Generate Beta Release Notes
         run: |
           BETA_TAG="${{ needs.version-management.outputs.beta_tag }}"
@@ -337,31 +379,19 @@ jobs:
           echo "버전: $VERSION" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
           
-          # 이전 베타 릴리즈의 릴리즈 노트 가져오기
-          if [[ "${{ needs.version-management.outputs.has_previous_beta }}" == "true" ]]; then
-            previous_beta="${{ needs.version-management.outputs.previous_beta }}"
-            echo "이전 베타 릴리즈 노트 병합 중: $previous_beta"
-            
-            # GitHub API를 통해 이전 릴리즈 노트 가져오기
-            previous_notes=$(curl -s -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
-              "https://api.github.com/repos/${{ github.repository }}/releases/tags/$previous_beta" \
-              | jq -r '.body // empty')
-            
-            if [ ! -z "$previous_notes" ]; then
-              # 헤더 부분을 제외한 변경 사항만 추출
-              changes=$(echo "$previous_notes" | awk '/^- /')
-              if [ ! -z "$changes" ]; then
-                echo "$changes" >> CHANGELOG.md
-                echo "" >> CHANGELOG.md
-              fi
-            fi
-          fi
-          
           # 새로운 변경 사항 추가
-          echo "### 새로운 변경 사항" >> CHANGELOG.md
+          echo "### 최신 변경 사항" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
           git log -1 --pretty=format:"- %s" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
+          
+          # 이전 베타 릴리즈의 변경 사항 추가 (있는 경우)
+          if [[ "${{ steps.get-previous-notes.outputs.has_changes }}" == "true" ]]; then
+            echo "### 이전 변경 사항" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+            echo "${{ steps.get-previous-notes.outputs.previous_changes }}" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+          fi
 
       - name: Create Beta Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## 🔧 베타 릴리즈 관리 개선

### 📋 문제점
- 베타 릴리즈 생성 시 이전 베타 릴리즈가 Draft 상태로 남아있음
- 이전 베타 릴리즈의 노트 내용이 새로운 릴리즈에 제대로 누적되지 않음
- 태그는 삭제되지만 GitHub 릴리즈는 남아있어 혼란 야기

### ✅ 해결 방안
1. **이전 베타 릴리즈 노트 보존**: 태그 삭제 전에 이전 릴리즈 노트를 먼저 가져와서 보존
2. **완전한 릴리즈 삭제**: GitHub API를 통해 이전 베타 릴리즈를 완전히 삭제
3. **누적된 릴리즈 노트**: 최신 변경사항과 이전 변경사항을 분리하여 표시
4. **처리 순서 개선**: 노트 가져오기 → 릴리즈 삭제 → 새 릴리즈 생성

### 🔄 변경된 워크플로우
1. `Get Previous Beta Release Notes`: 이전 베타 릴리즈 노트 추출
2. `Delete Previous Beta Release`: GitHub API로 이전 릴리즈 완전 삭제
3. `Generate Beta Release Notes`: 누적된 노트로 새 릴리즈 노트 생성
4. `Create Beta Release`: 개선된 노트로 새 베타 릴리즈 생성

### 📝 릴리즈 노트 구조
```
## 베타 릴리즈 노트
버전: v1.x.x-beta.timestamp

### 최신 변경 사항
- 현재 커밋의 변경사항

### 이전 변경 사항
- 이전 베타 릴리즈들의 누적된 변경사항
```

### 🎯 기대 효과
- ✅ Draft 상태의 베타 릴리즈 제거
- ✅ 모든 변경사항이 누적되어 관리됨
- ✅ 깔끔한 릴리즈 히스토리 유지
- ✅ 사용자 혼란 방지 