### PR TITLE
fix: 베타 릴리즈 관리 outputs 누락 및 조건문 개선

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -156,6 +156,8 @@ jobs:
     outputs:
       version_code: ${{ vars.VERSION_CODE }}
       beta_tag: ${{ steps.create-beta-tag.outputs.tag }}
+      has_previous_beta: ${{ steps.create-beta-tag.outputs.has_previous_beta }}
+      previous_beta: ${{ steps.create-beta-tag.outputs.previous_beta }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -329,44 +331,60 @@ jobs:
 
       - name: Get Previous Beta Release Notes
         id: get-previous-notes
-        if: needs.version-management.outputs.has_previous_beta == 'true'
         run: |
+          has_previous="${{ needs.version-management.outputs.has_previous_beta }}"
           previous_beta="${{ needs.version-management.outputs.previous_beta }}"
-          echo "이전 베타 릴리즈 노트 가져오는 중: $previous_beta"
           
-          # GitHub API를 통해 이전 릴리즈 노트 가져오기
-          previous_notes=$(curl -s -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/releases/tags/$previous_beta" \
-            | jq -r '.body // empty')
+          echo "has_previous_beta: $has_previous"
+          echo "previous_beta: $previous_beta"
           
-          if [ ! -z "$previous_notes" ] && [ "$previous_notes" != "null" ]; then
-            # 변경 사항 부분만 추출 (헤더 제외)
-            changes=$(echo "$previous_notes" | sed -n '/^- /p' | head -20)
-            echo "previous_changes<<EOF" >> $GITHUB_OUTPUT
-            echo "$changes" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+          if [[ "$has_previous" == "true" ]] && [[ ! -z "$previous_beta" ]]; then
+            echo "이전 베타 릴리즈 노트 가져오는 중: $previous_beta"
+            
+            # GitHub API를 통해 이전 릴리즈 노트 가져오기
+            previous_notes=$(curl -s -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/tags/$previous_beta" \
+              | jq -r '.body // empty')
+            
+            if [ ! -z "$previous_notes" ] && [ "$previous_notes" != "null" ]; then
+              # 변경 사항 부분만 추출 (헤더 제외)
+              changes=$(echo "$previous_notes" | sed -n '/^- /p' | head -20)
+              echo "previous_changes<<EOF" >> $GITHUB_OUTPUT
+              echo "$changes" >> $GITHUB_OUTPUT
+              echo "EOF" >> $GITHUB_OUTPUT
+              echo "has_changes=true" >> $GITHUB_OUTPUT
+              echo "이전 릴리즈 노트 가져오기 완료"
+            else
+              echo "has_changes=false" >> $GITHUB_OUTPUT
+              echo "이전 릴리즈 노트가 비어있음"
+            fi
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "이전 베타 릴리즈가 없음"
           fi
 
       - name: Delete Previous Beta Release
-        if: needs.version-management.outputs.has_previous_beta == 'true'
         run: |
+          has_previous="${{ needs.version-management.outputs.has_previous_beta }}"
           previous_beta="${{ needs.version-management.outputs.previous_beta }}"
-          echo "이전 베타 릴리즈 삭제 중: $previous_beta"
           
-          # GitHub API를 통해 이전 릴리즈 삭제
-          release_id=$(curl -s -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/releases/tags/$previous_beta" \
-            | jq -r '.id // empty')
-          
-          if [ ! -z "$release_id" ] && [ "$release_id" != "null" ]; then
-            curl -X DELETE -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
-              "https://api.github.com/repos/${{ github.repository }}/releases/$release_id"
-            echo "이전 베타 릴리즈 삭제 완료: $release_id"
+          if [[ "$has_previous" == "true" ]] && [[ ! -z "$previous_beta" ]]; then
+            echo "이전 베타 릴리즈 삭제 중: $previous_beta"
+            
+            # GitHub API를 통해 이전 릴리즈 삭제
+            release_id=$(curl -s -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/tags/$previous_beta" \
+              | jq -r '.id // empty')
+            
+            if [ ! -z "$release_id" ] && [ "$release_id" != "null" ]; then
+              curl -X DELETE -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
+                "https://api.github.com/repos/${{ github.repository }}/releases/$release_id"
+              echo "이전 베타 릴리즈 삭제 완료: $release_id"
+            else
+              echo "이전 베타 릴리즈를 찾을 수 없음"
+            fi
           else
-            echo "이전 베타 릴리즈를 찾을 수 없음"
+            echo "삭제할 이전 베타 릴리즈가 없음"
           fi
 
       - name: Generate Beta Release Notes


### PR DESCRIPTION
## 🐛 베타 릴리즈 관리 버그 수정

### 📋 문제점
- `Get Previous Beta Release Notes`와 `Delete Previous Beta Release` 스텝이 스킵되는 문제
- `version-management` 작업의 `outputs`에 `has_previous_beta`와 `previous_beta`가 누락됨
- 조건문에서 outputs 값을 제대로 참조하지 못함

### 🔍 원인 분석
1. **누락된 outputs**: `version-management` 작업에서 필요한 outputs가 정의되지 않음
2. **조건문 문제**: GitHub Actions의 조건문 평가에서 예상과 다른 동작
3. **디버깅 부족**: 조건 값들이 제대로 전달되는지 확인할 수 없음

### ✅ 해결 방안
1. **outputs 추가**: `has_previous_beta`와 `previous_beta` outputs 추가
2. **조건문 개선**: `if` 조건을 스텝 내부로 이동하여 더 안전하게 처리
3. **디버깅 로그 추가**: 조건 값들을 출력하여 디버깅 가능하도록 개선
4. **안전한 처리**: 빈 값이나 null 값에 대한 안전한 처리 추가

### 🔄 주요 변경사항

#### 1. outputs 추가
```yaml
outputs:
  version_code: ${{ vars.VERSION_CODE }}
  beta_tag: ${{ steps.create-beta-tag.outputs.tag }}
  has_previous_beta: ${{ steps.create-beta-tag.outputs.has_previous_beta }}  # 추가
  previous_beta: ${{ steps.create-beta-tag.outputs.previous_beta }}          # 추가
```

#### 2. 조건문 개선
- **이전**: `if: needs.version-management.outputs.has_previous_beta == 'true'`
- **이후**: 스텝 내부에서 조건 체크 및 안전한 처리

#### 3. 디버깅 로그 추가
```bash
echo "has_previous_beta: $has_previous"
echo "previous_beta: $previous_beta"
```

### 🎯 기대 효과
- ✅ 베타 릴리즈 관리 스텝이 정상적으로 실행됨
- ✅ 이전 베타 릴리즈가 올바르게 삭제됨
- ✅ Draft 상태의 베타 릴리즈 문제 해결
- ✅ 디버깅 가능한 로그 제공

### 🧪 테스트 방법
1. dev 브랜치에 PR 머지
2. GitHub Actions 로그에서 다음 확인:
   - `has_previous_beta` 값 출력
   - `previous_beta` 값 출력
   - 이전 릴리즈 삭제 로그
3. GitHub 릴리즈 페이지에서 Draft 상태 릴리즈 확인 