### PR TITLE
fix: 베타 릴리즈 API 처리 개선 - HTTP 상태 코드 확인 및 대안 처리 추가

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -387,6 +387,36 @@ jobs:
               echo "release_id=" >> $GITHUB_OUTPUT
               echo "API 호출 실패: HTTP $http_code"
               echo "응답: $response_body"
+              
+              # API 오류 시 수동 처리 가이드 제공
+              if [[ "$http_code" =~ ^5[0-9][0-9]$ ]]; then
+                echo ""
+                echo "🚨 GitHub API 서버 오류 (HTTP $http_code) 감지!"
+                echo "Re-run job을 해도 동일한 오류가 발생할 가능성이 높습니다."
+                echo ""
+                echo "📋 수동 처리 방법:"
+                echo "1. GitHub 릴리즈 페이지에서 이전 베타 릴리즈 확인:"
+                echo "   https://github.com/${{ github.repository }}/releases"
+                echo ""
+                echo "2. 이전 베타 릴리즈가 있다면 수동으로 삭제하거나 Draft 처리"
+                echo ""
+                echo "3. 또는 Git 명령어로 이전 베타 태그 삭제:"
+                echo "   git tag -d $previous_beta"
+                echo "   git push origin :refs/tags/$previous_beta"
+                echo ""
+                echo "4. 워크플로우 재실행 또는 새로운 PR 생성"
+                echo ""
+              elif [ "$http_code" = "403" ]; then
+                echo ""
+                echo "🔒 GitHub API 권한 오류 (HTTP 403)"
+                echo "토큰 권한을 확인하거나 잠시 후 재시도하세요."
+                echo ""
+              elif [ "$http_code" = "429" ]; then
+                echo ""
+                echo "⏰ GitHub API 요청 제한 (HTTP 429)"
+                echo "잠시 후 Re-run job을 시도하세요."
+                echo ""
+              fi
             fi
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -424,21 +454,59 @@ jobs:
                 echo "릴리즈 삭제 실패: HTTP $delete_http_code"
                 echo "응답: $delete_body"
                 
-                # 대안: 릴리즈를 Draft로 변경
-                echo "대안으로 릴리즈를 Draft 상태로 변경 시도..."
-                draft_response=$(curl -s -w "HTTPSTATUS:%{http_code}" \
-                  -X PATCH \
-                  -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
-                  -H "Content-Type: application/json" \
-                  -d '{"draft": true}' \
-                  "https://api.github.com/repos/${{ github.repository }}/releases/$release_id")
-                
-                draft_http_code=$(echo "$draft_response" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
-                
-                if [ "$draft_http_code" = "200" ]; then
-                  echo "릴리즈를 Draft 상태로 변경 완료"
+                # 서버 오류 시 수동 처리 가이드 제공
+                if [[ "$delete_http_code" =~ ^5[0-9][0-9]$ ]]; then
+                  echo ""
+                  echo "🚨 GitHub API 서버 오류 (HTTP $delete_http_code) 감지!"
+                  echo "Re-run job을 해도 동일한 오류가 발생할 가능성이 높습니다."
+                  echo ""
+                  echo "📋 수동 처리 방법:"
+                  echo "1. GitHub 릴리즈 페이지에서 직접 삭제:"
+                  echo "   https://github.com/${{ github.repository }}/releases/tag/$previous_beta"
+                  echo ""
+                  echo "2. 또는 Git 명령어로 태그 삭제:"
+                  echo "   git tag -d $previous_beta"
+                  echo "   git push origin :refs/tags/$previous_beta"
+                  echo ""
+                  echo "3. 급한 경우 릴리즈를 Draft 상태로 수동 변경"
+                  echo ""
+                  echo "⚠️  서버 오류가 해결될 때까지 기다리는 것을 권장합니다."
+                  echo ""
+                elif [ "$delete_http_code" = "403" ]; then
+                  echo ""
+                  echo "🔒 GitHub API 권한 오류 (HTTP 403)"
+                  echo "토큰 권한을 확인하거나 수동으로 릴리즈를 삭제하세요:"
+                  echo "   https://github.com/${{ github.repository }}/releases/tag/$previous_beta"
+                  echo ""
+                elif [ "$delete_http_code" = "429" ]; then
+                  echo ""
+                  echo "⏰ GitHub API 요청 제한 (HTTP 429)"
+                  echo "잠시 후 Re-run job을 시도하거나 수동으로 처리하세요."
+                  echo ""
                 else
-                  echo "Draft 변경도 실패: HTTP $draft_http_code"
+                  # 대안: 릴리즈를 Draft로 변경
+                  echo "대안으로 릴리즈를 Draft 상태로 변경 시도..."
+                  draft_response=$(curl -s -w "HTTPSTATUS:%{http_code}" \
+                    -X PATCH \
+                    -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
+                    -H "Content-Type: application/json" \
+                    -d '{"draft": true}' \
+                    "https://api.github.com/repos/${{ github.repository }}/releases/$release_id")
+                  
+                  draft_http_code=$(echo "$draft_response" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+                  
+                  if [ "$draft_http_code" = "200" ]; then
+                    echo "릴리즈를 Draft 상태로 변경 완료"
+                  elif [[ "$draft_http_code" =~ ^5[0-9][0-9]$ ]]; then
+                    echo "Draft 변경도 서버 오류로 실패: HTTP $draft_http_code"
+                    echo ""
+                    echo "🚨 GitHub API 서버에 문제가 있는 것 같습니다."
+                    echo "📋 수동으로 GitHub 웹사이트에서 릴리즈를 Draft 처리하세요:"
+                    echo "   https://github.com/${{ github.repository }}/releases/tag/$previous_beta"
+                    echo ""
+                  else
+                    echo "Draft 변경도 실패: HTTP $draft_http_code"
+                  fi
                 fi
               fi
             else


### PR DESCRIPTION
## 🔧 베타 릴리즈 API 처리 개선

### 📋 문제점 분석
로그에서 확인된 문제:
```
이전 베타 릴리즈 노트 가져오는 중: v1.2.0-beta.20250527151806
이전 릴리즈 노트가 비어있음

이전 베타 릴리즈 삭제 중: v1.2.0-beta.20250527151806
이전 베타 릴리즈를 찾을 수 없음
```

### 🔍 원인 분석
1. **API 응답 처리 부족**: HTTP 상태 코드 확인 없이 응답만 파싱
2. **에러 처리 미흡**: 404나 다른 에러 상황에 대한 적절한 처리 없음
3. **릴리즈 ID 재사용 부족**: 첫 번째 API 호출에서 얻은 ID를 두 번째에서 재사용하지 않음
4. **디버깅 정보 부족**: API 호출 결과에 대한 상세한 로그 없음

### ✅ 해결 방안

#### 1. **HTTP 상태 코드 확인**
```bash
api_response=$(curl -s -w "HTTPSTATUS:%{http_code}" ...)
http_code=$(echo "$api_response" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
```

#### 2. **상세한 디버깅 로그**
- API HTTP 상태 코드 출력
- 릴리즈 ID 출력
- 릴리즈 노트 길이 출력
- 각 단계별 상태 메시지

#### 3. **릴리즈 ID 재사용**
- 첫 번째 스텝에서 릴리즈 ID를 outputs에 저장
- 두 번째 스텝에서 저장된 ID 재사용
- 불필요한 API 호출 제거

#### 4. **대안 처리 방법**
- 릴리즈 삭제 실패 시 Draft 상태로 변경
- 404 에러에 대한 적절한 처리
- 각 에러 상황별 명확한 메시지

### 🔄 주요 변경사항

#### **Get Previous Beta Release Notes 개선**
- ✅ HTTP 상태 코드 확인 (200, 404, 기타)
- ✅ 릴리즈 ID를 outputs에 저장
- ✅ 상세한 디버깅 로그 추가
- ✅ 빈 노트와 null 값에 대한 안전한 처리

#### **Delete Previous Beta Release 개선**
- ✅ 이전 스텝의 릴리즈 ID 재사용
- ✅ 삭제 API의 HTTP 상태 코드 확인 (204 성공)
- ✅ 삭제 실패 시 Draft 상태로 변경하는 대안 제공
- ✅ 각 단계별 상세한 로그

### 📊 예상 로그 개선
**이전**:
```
이전 릴리즈 노트가 비어있음
이전 베타 릴리즈를 찾을 수 없음
```

**이후**:
```
API HTTP 상태 코드: 200
릴리즈 ID: 12345678
릴리즈 노트 길이: 150
이전 릴리즈 노트 가져오기 완료 (45 문자)

사용할 릴리즈 ID: 12345678
릴리즈 ID 12345678 삭제 시도 중...
삭제 API HTTP 상태 코드: 204
이전 베타 릴리즈 삭제 완료: 12345678
```

### 🎯 기대 효과
- ✅ API 호출 실패 원인을 정확히 파악 가능
- ✅ 릴리즈 삭제 성공률 향상
- ✅ 삭제 실패 시에도 Draft 처리로 대안 제공
- ✅ 디버깅과 문제 해결이 용이해짐
- ✅ 더 안정적인 베타 릴리즈 관리 