### PR TITLE
fix: 베타 태그 삭제 순서 수정 - 릴리즈 정보 확인 후 태그 삭제

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -256,9 +256,7 @@ jobs:
           if [ ! -z "$previous_beta" ]; then
             echo "has_previous_beta=true" >> $GITHUB_OUTPUT
             echo "previous_beta=$previous_beta" >> $GITHUB_OUTPUT
-            # 이전 베타 태그 삭제
-            git tag -d "$previous_beta"
-            git push origin ":refs/tags/$previous_beta"
+            echo "이전 베타 태그 발견: $previous_beta (릴리즈 작업에서 삭제 예정)"
           fi
           
           echo "Creating beta tag: $beta_tag (based on $latest_release)"
@@ -450,6 +448,12 @@ jobs:
               
               if [ "$delete_http_code" = "204" ]; then
                 echo "이전 베타 릴리즈 삭제 완료: $release_id"
+                
+                # 릴리즈 삭제 성공 후 태그도 삭제
+                echo "이전 베타 태그 삭제 중: $previous_beta"
+                git tag -d "$previous_beta" 2>/dev/null || echo "로컬 태그가 없거나 이미 삭제됨"
+                git push origin ":refs/tags/$previous_beta" 2>/dev/null || echo "원격 태그가 없거나 이미 삭제됨"
+                echo "이전 베타 태그 삭제 완료: $previous_beta"
               else
                 echo "릴리즈 삭제 실패: HTTP $delete_http_code"
                 echo "응답: $delete_body"
@@ -497,6 +501,12 @@ jobs:
                   
                   if [ "$draft_http_code" = "200" ]; then
                     echo "릴리즈를 Draft 상태로 변경 완료"
+                    
+                    # Draft 처리 성공 후 태그도 삭제
+                    echo "이전 베타 태그 삭제 중: $previous_beta"
+                    git tag -d "$previous_beta" 2>/dev/null || echo "로컬 태그가 없거나 이미 삭제됨"
+                    git push origin ":refs/tags/$previous_beta" 2>/dev/null || echo "원격 태그가 없거나 이미 삭제됨"
+                    echo "이전 베타 태그 삭제 완료: $previous_beta"
                   elif [[ "$draft_http_code" =~ ^5[0-9][0-9]$ ]]; then
                     echo "Draft 변경도 서버 오류로 실패: HTTP $draft_http_code"
                     echo ""
@@ -510,8 +520,14 @@ jobs:
                 fi
               fi
             else
-              echo "유효한 릴리즈 ID가 없음 - 삭제할 수 없음"
+              echo "유효한 릴리즈 ID가 없음 - 릴리즈는 삭제할 수 없음"
               echo "이전 스텝에서 릴리즈를 찾지 못했거나 이미 삭제됨"
+              
+              # 릴리즈는 없지만 태그는 있을 수 있으므로 태그만 삭제 시도
+              echo "이전 베타 태그만 삭제 시도: $previous_beta"
+              git tag -d "$previous_beta" 2>/dev/null || echo "로컬 태그가 없거나 이미 삭제됨"
+              git push origin ":refs/tags/$previous_beta" 2>/dev/null || echo "원격 태그가 없거나 이미 삭제됨"
+              echo "이전 베타 태그 삭제 시도 완료: $previous_beta"
             fi
           else
             echo "삭제할 이전 베타 릴리즈가 없음"


### PR DESCRIPTION
## 🔧 베타 태그 삭제 순서 수정

### 📋 문제점 분석
로그에서 확인된 문제:
```
has_previous_beta: true
previous_beta: v1.2.0-beta.20250527152642
이전 베타 릴리즈 노트 가져오는 중: v1.2.0-beta.20250527152642
API HTTP 상태 코드: 404
이전 베타 릴리즈를 찾을 수 없음 (404)
```

### 🔍 원인 분석
**잘못된 삭제 순서**:
1. `version-management` 작업에서 **태그를 먼저 삭제**
2. `create-beta-release` 작업에서 **삭제된 태그로 릴리즈 검색** → 404 에러

베타 릴리즈는 태그명을 기반으로 생성되므로, 태그가 삭제되면 GitHub API에서 해당 릴리즈를 찾을 수 없게 됩니다.

### ✅ 해결 방안

#### **올바른 삭제 순서**:
1. **릴리즈 정보 확인** (태그가 있는 상태에서)
2. **릴리즈 삭제** 또는 **Draft 처리**
3. **태그 삭제**

### 🔄 주요 변경사항

#### **1. version-management 작업 수정**
**이전**:
```bash
# 이전 베타 태그 삭제
git tag -d "$previous_beta"
git push origin ":refs/tags/$previous_beta"
```

**이후**:
```bash
echo "이전 베타 태그 발견: $previous_beta (릴리즈 작업에서 삭제 예정)"
```

#### **2. create-beta-release 작업 강화**

##### **릴리즈 삭제 성공 시**:
```bash
echo "이전 베타 릴리즈 삭제 완료: $release_id"

# 릴리즈 삭제 성공 후 태그도 삭제
echo "이전 베타 태그 삭제 중: $previous_beta"
git tag -d "$previous_beta" 2>/dev/null || echo "로컬 태그가 없거나 이미 삭제됨"
git push origin ":refs/tags/$previous_beta" 2>/dev/null || echo "원격 태그가 없거나 이미 삭제됨"
echo "이전 베타 태그 삭제 완료: $previous_beta"
```

##### **Draft 처리 성공 시**:
```bash
echo "릴리즈를 Draft 상태로 변경 완료"

# Draft 처리 성공 후 태그도 삭제
echo "이전 베타 태그 삭제 중: $previous_beta"
git tag -d "$previous_beta" 2>/dev/null || echo "로컬 태그가 없거나 이미 삭제됨"
git push origin ":refs/tags/$previous_beta" 2>/dev/null || echo "원격 태그가 없거나 이미 삭제됨"
echo "이전 베타 태그 삭제 완료: $previous_beta"
```

##### **릴리즈를 찾을 수 없는 경우**:
```bash
echo "유효한 릴리즈 ID가 없음 - 릴리즈는 삭제할 수 없음"
echo "이전 스텝에서 릴리즈를 찾지 못했거나 이미 삭제됨"

# 릴리즈는 없지만 태그는 있을 수 있으므로 태그만 삭제 시도
echo "이전 베타 태그만 삭제 시도: $previous_beta"
git tag -d "$previous_beta" 2>/dev/null || echo "로컬 태그가 없거나 이미 삭제됨"
git push origin ":refs/tags/$previous_beta" 2>/dev/null || echo "원격 태그가 없거나 이미 삭제됨"
echo "이전 베타 태그 삭제 시도 완료: $previous_beta"
```

### 📊 예상 로그 개선

**이전**:
```
API HTTP 상태 코드: 404
이전 베타 릴리즈를 찾을 수 없음 (404)
유효한 릴리즈 ID가 없음 - 삭제할 수 없음
```

**이후**:
```
API HTTP 상태 코드: 200
릴리즈 ID: 12345678
릴리즈 노트 길이: 150
이전 릴리즈 노트 가져오기 완료 (45 문자)

릴리즈 ID 12345678 삭제 시도 중...
삭제 API HTTP 상태 코드: 204
이전 베타 릴리즈 삭제 완료: 12345678
이전 베타 태그 삭제 중: v1.2.0-beta.20250527152642
이전 베타 태그 삭제 완료: v1.2.0-beta.20250527152642
```

### 🎯 기대 효과
- ✅ **404 에러 해결**: 태그가 있는 상태에서 릴리즈 검색
- ✅ **완전한 정리**: 릴리즈와 태그 모두 안전하게 삭제
- ✅ **안전한 처리**: 각 단계별 에러 처리 및 대안 제공
- ✅ **명확한 로그**: 각 삭제 단계별 상세한 상태 메시지

### 🧪 테스트 시나리오
1. **정상 케이스**: 릴리즈 찾기 → 삭제 → 태그 삭제
2. **Draft 케이스**: 릴리즈 찾기 → Draft 처리 → 태그 삭제  
3. **404 케이스**: 릴리즈 없음 → 태그만 삭제
4. **에러 케이스**: API 오류 → 수동 처리 가이드 