### PR TITLE
fix: Version Code 관리 방식 개선

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,8 +64,10 @@ jobs:
           BUILD_TIMESTAMP: ${{ steps.set-timestamp.outputs.value }}
         run: |
           if [[ "${{ github.base_ref }}" == "main" ]]; then
+            echo "Building release APK with version code: $VERSION_CODE"
             ./gradlew assembleRelease -Prelease
           else
+            echo "Building debug APK with version code: $VERSION_CODE"
             ./gradlew assembleDebug
           fi
 
@@ -88,7 +90,7 @@ jobs:
       contents: write
       actions: write
     outputs:
-      version_code: ${{ vars.VERSION_CODE }}
+      version_code: ${{ steps.create-beta-tag.outputs.version_code }}
       beta_tag: ${{ steps.create-beta-tag.outputs.tag }}
       has_previous_beta: ${{ steps.create-beta-tag.outputs.has_previous_beta }}
       previous_beta: ${{ steps.create-beta-tag.outputs.previous_beta }}
@@ -98,27 +100,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           token: ${{ secrets.ADMIN_TOKEN }}
-
-      - name: Update Version Code
-        id: version-update
-        uses: actions/github-script@v7
-        env:
-          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
-        with:
-          github-token: ${{ secrets.ADMIN_TOKEN }}
-          script: |
-            const currentVersion = parseInt('${{ vars.VERSION_CODE }}') || 0;
-            const newVersion = currentVersion + 1;
-            
-            await github.rest.actions.updateRepoVariable({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'VERSION_CODE',
-              value: newVersion.toString()
-            });
-            
-            console.log(`Version Code updated: ${currentVersion} → ${newVersion}`);
-            core.setOutput('new_version', newVersion.toString());
 
       - name: Create Beta Tag
         id: create-beta-tag
@@ -181,10 +162,12 @@ jobs:
           # 이전 베타 태그 찾기 (같은 버전의 가장 최신 베타)
           previous_beta=$(git tag -l "v${next_version}-beta*" | sort -V | tail -n 1)
           
-          # 새로운 베타 태그 생성
+          # 새로운 베타 태그 생성 (현재 version code 사용)
+          current_version_code="${{ vars.VERSION_CODE }}"
           beta_tag="v$next_version-beta.${{ needs.build-for-deploy.outputs.timestamp }}"
           echo "tag=$beta_tag" >> $GITHUB_OUTPUT
           echo "version=$next_version" >> $GITHUB_OUTPUT
+          echo "version_code=$current_version_code" >> $GITHUB_OUTPUT
           echo "has_previous_beta=false" >> $GITHUB_OUTPUT
           
           if [ ! -z "$previous_beta" ]; then
@@ -193,8 +176,8 @@ jobs:
             echo "이전 베타 태그 발견: $previous_beta (릴리즈 작업에서 삭제 예정)"
           fi
           
-          echo "Creating beta tag: $beta_tag (based on $latest_release)"
-          git tag -a "$beta_tag" -m "Beta release $beta_tag"
+          echo "Creating beta tag: $beta_tag (version code: $current_version_code, based on $latest_release)"
+          git tag -a "$beta_tag" -m "Beta release $beta_tag (version code: $current_version_code)"
           git push origin "$beta_tag"
 
   # main 브랜치 머지 시 릴리즈 태그 생성
@@ -205,14 +188,37 @@ jobs:
     if: github.base_ref == 'main'
     permissions:
       contents: write
+      actions: write
     outputs:
       release_tag: ${{ steps.create-release-tag.outputs.tag }}
+      new_version_code: ${{ steps.version-update.outputs.new_version }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           token: ${{ secrets.ADMIN_TOKEN }}
+
+      - name: Update Version Code
+        id: version-update
+        uses: actions/github-script@v7
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        with:
+          github-token: ${{ secrets.ADMIN_TOKEN }}
+          script: |
+            const currentVersion = parseInt('${{ vars.VERSION_CODE }}') || 0;
+            const newVersion = currentVersion + 1;
+            
+            await github.rest.actions.updateRepoVariable({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'VERSION_CODE',
+              value: newVersion.toString()
+            });
+            
+            console.log(`Version Code updated: ${currentVersion} → ${newVersion}`);
+            core.setOutput('new_version', newVersion.toString());
 
       - name: Create Release Tag
         id: create-release-tag
@@ -465,10 +471,12 @@ jobs:
         run: |
           BETA_TAG="${{ needs.version-management.outputs.beta_tag }}"
           VERSION="${BETA_TAG#v}"
+          VERSION_CODE="${{ needs.version-management.outputs.version_code }}"
           
           echo "## 베타 릴리즈 노트" > CHANGELOG.md
           echo "" >> CHANGELOG.md
-          echo "버전: $VERSION" >> CHANGELOG.md
+          echo "**버전**: $VERSION" >> CHANGELOG.md
+          echo "**Version Code**: $VERSION_CODE" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
           
           # 새로운 변경 사항 추가
@@ -524,10 +532,12 @@ jobs:
         run: |
           RELEASE_TAG="${{ needs.create-release-tag.outputs.release_tag }}"
           VERSION="${RELEASE_TAG#v}"
+          VERSION_CODE="${{ needs.create-release-tag.outputs.new_version_code }}"
           
           echo "## 릴리즈 노트" > CHANGELOG.md
           echo "" >> CHANGELOG.md
-          echo "버전: $VERSION" >> CHANGELOG.md
+          echo "**버전**: $VERSION" >> CHANGELOG.md
+          echo "**Version Code**: $VERSION_CODE" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
           
           previous_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")


### PR DESCRIPTION
## 🔧 Version Code 관리 방식 개선

### 🎯 문제점
기존에는 dev 브랜치에 머지할 때마다 version code가 증가하여:
- 릴리즈 버전과 베타 버전 간의 version code 차이가 불규칙
- APK 설치 시 버전 충돌 가능성
- 베타 테스트 후 정식 릴리즈로 업그레이드 시 문제 발생 가능

### ✨ 개선된 방식

#### 📋 **새로운 Version Code 관리 흐름**
```
현재 VERSION_CODE = 21

dev 머지들 → 베타 릴리즈들 (version code: 21)
main 머지 → 정식 릴리즈 (version code: 21) + VERSION_CODE → 22
이후 dev 머지들 → 베타 릴리즈들 (version code: 22)
```

#### 🔄 **변경사항**

1. **Version Code 업데이트 시점 변경**
   - ❌ 기존: dev 머지 시마다 +1
   - ✅ 개선: main 머지 시에만 +1

2. **베타 릴리즈**
   - 현재 version code 사용 (변경 없음)
   - 같은 버전의 베타들은 모두 동일한 version code

3. **정식 릴리즈**
   - 베타와 동일한 version code로 릴리즈 생성
   - 릴리즈 후 다음 버전을 위해 version code +1

4. **릴리즈 노트 개선**
   - 버전과 version code 모두 명시
   - 태그 메시지에 version code 포함

### 🎯 기대 효과

1. **깔끔한 버전 관리**
   - 베타: version code N
   - 릴리즈: version code N  
   - 다음 베타: version code N+1

2. **APK 설치 문제 해결**
   - 베타 → 릴리즈: 동일한 version code (덮어쓰기)
   - 릴리즈 → 다음 베타: version code +1 (업그레이드)

3. **명확한 버전 히스토리**
   - 각 릴리즈 사이클마다 version code 1씩 증가
   - 예측 가능한 버전 관리

### 📝 예시 시나리오

```
현재: VERSION_CODE = 21

1. dev 머지 → v1.3.0-beta.20250101120000 (version code: 21)
2. dev 머지 → v1.3.0-beta.20250102130000 (version code: 21)  
3. main 머지 → v1.3.0 (version code: 21) + VERSION_CODE → 22
4. dev 머지 → v1.3.1-beta.20250103140000 (version code: 22)
```

### 🔍 테스트 방법

1. 이 PR 머지 후 dev에 새로운 PR 머지하여 베타 릴리즈 생성
2. 베타 릴리즈의 version code가 현재 값(21) 사용하는지 확인
3. main으로 PR 머지하여 정식 릴리즈 생성 및 version code 업데이트 확인 