### PR TITLE
feat: Debug 빌드 구분 개선

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,7 @@ android {
         val releaseProps = loadConfigProperties("release")
 
         debug {
+            applicationIdSuffix = ".debug"
             debugProps.forEach { (key, value) ->
                 buildConfigField("String", key.toString(), "\"$value\"")
             }

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Android Toy (Debug)</string>
-    <string name="app_display_name">안드로이드 디버그</string>
+    <string name="app_display_name">안드로이드 (Debug)</string>
     <string name="api_url">https://dev-api.example.com</string>
 </resources>


### PR DESCRIPTION
## 🔧 Debug 빌드 구분 개선

### 🎯 문제점
현재 Debug와 Release 빌드가 동일한 Application ID를 사용하여:
- 에뮬레이터/디바이스에서 동시 설치 불가능
- 베타 테스트와 정식 릴리즈 버전 구분 어려움
- 개발 중 두 버전을 비교 테스트하기 어려움

### ✨ 개선사항

#### 📱 **Application ID 분리**
```kotlin
// Debug 빌드
applicationId = "toy.practice.androidtest.debug"

// Release 빌드  
applicationId = "toy.practice.androidtest"
```

#### 🏷️ **앱 이름 구분**
```xml
<!-- Debug 빌드 -->
<string name="app_name">Android Toy (Debug)</string>
<string name="app_display_name">안드로이드 (Debug)</string>

<!-- Release 빌드 -->
<string name="app_name">Android Toy</string>
<string name="app_display_name">안드로이드</string>
```

### 🎯 기대 효과

1. **동시 설치 가능**
   - 베타 APK와 릴리즈 APK를 동시에 설치하여 비교 테스트
   - 개발자와 QA팀의 테스트 효율성 향상

2. **명확한 구분**
   - 홈 화면에서 "(Debug)" 표시로 개발 빌드 구분
   - 실수로 잘못된 버전 사용 방지

3. **개발 편의성**
   - 베타 테스트 중에도 정식 버전 사용 가능
   - 버전 간 기능 비교 및 검증 용이

### 📋 변경된 파일

1. **`app/build.gradle.kts`**
   - Debug 빌드에 `applicationIdSuffix = ".debug"` 추가

2. **`app/src/debug/res/values/strings.xml`** (신규)
   - Debug 전용 앱 이름 정의

### 🔍 테스트 방법

1. Debug APK 빌드 후 설치
2. Release APK 빌드 후 설치  
3. 에뮬레이터에서 두 앱이 동시 존재하는지 확인
4. 앱 이름에 "(Debug)" 표시 확인

### 📱 예상 결과

```
홈 화면에서:
📱 Android Toy (Debug)    ← 베타/개발 버전
📱 Android Toy            ← 정식 릴리즈 버전
``` 