### PR TITLE
fix: CD 워크플로우 Concurrency 개선

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,9 +5,9 @@ on:
     types: [closed]
     branches: ["dev", "main"]
 
-# 배포 작업은 순차적으로 실행
+# 배포 작업은 브랜치별로 순차적으로 실행 (여러 PR 동시 머지 시 대기열 처리)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.base_ref }}
+  group: "cd-${{ github.base_ref }}"
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## 🔒 CD 워크플로우 Concurrency 개선

### 🎯 문제점
현재 여러 PR을 동시에 dev 브랜치에 머지할 때:
- 베타 릴리즈가 동시에 생성되어 충돌 가능
- 이전 베타 릴리즈 삭제 로직이 꼬일 수 있음
- 릴리즈 노트에서 변경사항 누락 가능
- Version Code 동시 접근으로 인한 경합 상태

### ✨ 개선사항

#### 🔧 **Concurrency 설정 변경**

**기존**:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.base_ref }}
  cancel-in-progress: false
```

**개선**:
```yaml
concurrency:
  group: "cd-${{ github.base_ref }}"
  cancel-in-progress: false
```

#### 🔄 **동작 방식**

```
여러 PR 동시 머지 시:

시간: 12:00:00 - PR #37 dev 머지 → "cd-dev" Lock 획득
시간: 12:00:30 - PR #38 dev 머지 → "cd-dev" 대기열 진입  
시간: 12:01:00 - PR #39 dev 머지 → "cd-dev" 대기열 진입

실행 순서:
1. PR #37 CD 워크플로우 실행 (5-10분)
2. PR #37 완료 후 → PR #38 자동 시작
3. PR #38 완료 후 → PR #39 자동 시작
```

### 🎯 기대 효과

1. **자동 순차 실행**
   - 수동 관리 없이 안전한 순차 처리
   - 개발자 개입 불필요

2. **베타 릴리즈 안전성**
   - 동시 생성으로 인한 충돌 방지
   - 이전 베타 삭제 로직 안정성 확보

3. **릴리즈 노트 완전성**
   - 모든 변경사항 누락 없이 누적
   - 정확한 변경 히스토리 유지

4. **Version Code 안전성**
   - 동시 접근 방지로 경합 상태 해결
   - 일관된 버전 관리

### 📋 브랜치별 독립성

- **dev 브랜치**: `cd-dev` 그룹으로 순차 실행
- **main 브랜치**: `cd-main` 그룹으로 순차 실행  
- **브랜치 간 독립**: dev와 main 배포는 서로 영향 없음

### 🔍 테스트 시나리오

1. 여러 PR을 빠르게 연속으로 dev에 머지
2. GitHub Actions에서 대기열 형성 확인
3. 순차적으로 베타 릴리즈 생성 확인
4. 각 릴리즈 노트에 모든 변경사항 포함 확인

### 💡 추가 고려사항

이 개선으로 개발팀은:
- PR 머지 타이밍을 신경 쓸 필요 없음
- 안전하게 동시 작업 가능
- 릴리즈 프로세스의 신뢰성 확보 