### PR TITLE
fix: Version Code 경합 상태 해결

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,53 +82,53 @@ jobs:
       artifact_name: ${{ steps.set-artifact-name.outputs.value }}
     steps:
       - uses: actions/checkout@v4
-          with:
-            ref: ${{ github.event.pull_request.merge_commit_sha }}
-            fetch-depth: 0
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
         
-        - name: Set up JDK 17
-          uses: actions/setup-java@v4
-          with:
-            java-version: '17'
-            distribution: 'temurin'
-            cache: gradle
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
 
-        - name: Run Unit Tests
-          run: ./gradlew testDebugUnitTest
-          
-        - name: Upload Test Results
-          if: always()
-          uses: actions/upload-artifact@v4
-          with:
-            name: test-results-deploy-main
-            path: app/build/reports/tests/testDebugUnitTest/
+      - name: Run Unit Tests
+        run: ./gradlew testDebugUnitTest
+        
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-deploy-main
+          path: app/build/reports/tests/testDebugUnitTest/
 
-        - name: Set Timestamp
-          id: set-timestamp
-          env:
-            TZ: 'Asia/Seoul'
-          run: echo "value=$(date +%Y%m%d%H%M%S)" >> $GITHUB_OUTPUT
+      - name: Set Timestamp
+        id: set-timestamp
+        env:
+          TZ: 'Asia/Seoul'
+        run: echo "value=$(date +%Y%m%d%H%M%S)" >> $GITHUB_OUTPUT
 
-        - name: Set Artifact Name
-          id: set-artifact-name
-          run: echo "value=release-build" >> $GITHUB_OUTPUT
+      - name: Set Artifact Name
+        id: set-artifact-name
+        run: echo "value=release-build" >> $GITHUB_OUTPUT
 
-        - name: Build APK
-          env:
-            VERSION_CODE: ${{ vars.VERSION_CODE }}
-            BUILD_TIMESTAMP: ${{ steps.set-timestamp.outputs.value }}
-          run: |
-            echo "Building release APK with version code: $VERSION_CODE"
-            ./gradlew assembleRelease -Prelease
+      - name: Build APK
+        env:
+          VERSION_CODE: ${{ vars.VERSION_CODE }}
+          BUILD_TIMESTAMP: ${{ steps.set-timestamp.outputs.value }}
+        run: |
+          echo "Building release APK with version code: $VERSION_CODE"
+          ./gradlew assembleRelease -Prelease
 
-        - name: Upload Build Artifact
-          uses: actions/upload-artifact@v4
-          with:
-            name: ${{ steps.set-artifact-name.outputs.value }}
-            path: |
-              app/build/outputs/apk/**/*.apk
-              app/build/outputs/apk/**/output-metadata.json
-            retention-days: 30
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set-artifact-name.outputs.value }}
+          path: |
+            app/build/outputs/apk/**/*.apk
+            app/build/outputs/apk/**/output-metadata.json
+          retention-days: 30
 
   # 버전 관리 작업 (dev 브랜치 머지 시에만)
   version-management:

--- a/.pr-description.md
+++ b/.pr-description.md
@@ -1,6 +1,6 @@
-## 🔧 Version Code 경합 상태 해결
+## 🔧 Version Code 경합 상태 및 APK 빌드 순서 문제 해결
 
-### ⚠️ **문제 시나리오**
+### ⚠️ **문제 시나리오 1: 베타 릴리즈 경합 상태**
 
 dev와 main 브랜치에 동시 머지 시 발생할 수 있는 경합 상태:
 
@@ -10,6 +10,21 @@ dev와 main 브랜치에 동시 머지 시 발생할 수 있는 경합 상태:
 시간: 12:05:00 - PR #A 베타 릴리즈 생성 (version code: 21 사용) ❌
 
 결과: 베타가 구버전 코드 사용!
+```
+
+### ⚠️ **문제 시나리오 2: main 머지 시 APK 빌드 순서**
+
+```
+1. 베타 릴리즈: version code 21
+2. main 머지 시작: APK 빌드 (version code 21 사용) ❌
+3. 새 베타 릴리즈: version code 21 
+4. main 릴리즈 완료: VERSION_CODE 21→22 업데이트 (하지만 APK는 이미 21로 빌드됨)
+5. 3번 베타를 main에 머지: 
+   - APK 빌드 시 version code 22 사용
+   - VERSION_CODE 22→23 업데이트
+   - 릴리즈 노트에 23 표시 ❌ (APK는 22인데 노트는 23)
+
+결과: APK와 릴리즈 노트의 version code 불일치!
 ```
 
 ### 🎯 **문제점**
@@ -24,7 +39,7 @@ dev와 main 브랜치에 동시 머지 시 발생할 수 있는 경합 상태:
 
 ### ✨ **해결 방법**
 
-#### 🔄 **베타 릴리즈 생성 시 최신 VERSION_CODE 재확인**
+#### 🔄 **1. 베타 릴리즈 생성 시 최신 VERSION_CODE 재확인**
 
 ```yaml
 - name: Get Latest Version Code
@@ -46,7 +61,36 @@ dev와 main 브랜치에 동시 머지 시 발생할 수 있는 경합 상태:
     }
 ```
 
-#### 📝 **릴리즈 노트에 변경 알림 추가**
+#### 🏗️ **2. main 머지 시 Version Code 업데이트 순서 변경**
+
+**기존**: APK 빌드 → VERSION_CODE 업데이트
+**개선**: VERSION_CODE 업데이트 → APK 빌드
+
+```yaml
+# 1단계: Version Code 먼저 업데이트
+update-version-code:
+  name: Update Version Code
+  if: github.base_ref == 'main'
+  steps:
+    - name: Update Version Code
+      script: |
+        const newVersion = currentVersion + 1;
+        await github.rest.actions.updateRepoVariable({
+          name: 'VERSION_CODE',
+          value: newVersion.toString()
+        });
+
+# 2단계: 업데이트된 Version Code로 APK 빌드
+build-for-deploy-main:
+  name: Build for Deploy (Main)
+  needs: [update-version-code]
+  steps:
+    - name: Build APK
+      env:
+        VERSION_CODE: ${{ vars.VERSION_CODE }}  # 이미 업데이트된 값
+```
+
+#### 📝 **3. 릴리즈 노트에 변경 알림 추가**
 
 ```markdown
 **Version Code**: 22
@@ -55,7 +99,7 @@ dev와 main 브랜치에 동시 머지 시 발생할 수 있는 경합 상태:
 
 ### 🎯 **개선 효과**
 
-#### **안전한 Version Code 관리**
+#### **1. 베타 릴리즈 경합 상태 해결**
 ```
 시간: 12:00:00 - PR #A dev 머지 → CD 시작 (VERSION_CODE=21)
 시간: 12:02:00 - PR #B main 머지 → VERSION_CODE=21→22
@@ -64,24 +108,52 @@ dev와 main 브랜치에 동시 머지 시 발생할 수 있는 경합 상태:
 결과: 베타가 최신 version code 사용!
 ```
 
-#### **예상 시나리오**
+#### **2. main 머지 시 APK와 릴리즈 노트 일치**
 ```
-1. 베타 릴리즈: version code 22
-2. 정식 릴리즈: version code 22 (동일)  
-3. 다음 베타: version code 23 (정상 증가)
+기존 문제:
+1. 베타 릴리즈: version code 21
+2. main 머지: APK(21) + 릴리즈노트(22) ❌ 불일치!
+
+개선 후:
+1. 베타 릴리즈: version code 21  
+2. main 머지: VERSION_CODE 21→22 업데이트
+3. main 머지: APK(22) + 릴리즈노트(22) ✅ 일치!
+```
+
+#### **3. 사용자 시나리오 예상 결과**
+```
+1. 베타 릴리즈: version code 21
+2. main에 머지 (아직 version code 21)
+3. 새 베타 릴리즈: version code 21 (CD 먼저 완료)
+4. main 릴리즈 완료: version code 22 (APK도 22로 빌드됨) ✅
+5. 3번 베타를 main에 머지: 
+   - VERSION_CODE 22→23 업데이트
+   - APK version code 23으로 빌드 ✅
+   - 릴리즈 노트에 23 표시 ✅
+
+결과: APK와 릴리즈 노트 완전 일치!
 ```
 
 ### 🔍 **변경사항**
 
-1. **`Get Latest Version Code` 스텝 추가**
+1. **워크플로우 작업 분리 및 순서 변경**
+   - `build-for-deploy` → `build-for-deploy-dev` + `build-for-deploy-main`으로 분리
+   - main 머지 시: `update-version-code` → `build-for-deploy-main` 순서로 실행
+   - dev 머지 시: 기존 순서 유지
+
+2. **`Get Latest Version Code` 스텝 추가**
    - GitHub API로 최신 VERSION_CODE 재확인
    - 변경 여부 감지 및 로깅
 
-2. **릴리즈 노트 개선**
+3. **릴리즈 노트 개선**
    - 최신 version code 사용
    - 변경 시 사용자에게 알림 표시
 
-3. **투명한 로깅**
+4. **의존성 관계 명확화**
+   - dev: `build-for-deploy-dev` → `version-management` → `create-beta-release`
+   - main: `update-version-code` → `build-for-deploy-main` → `create-release-tag` → `create-release`
+
+5. **투명한 로깅**
    - 원본 vs 최신 version code 비교
    - 변경 감지 시 명확한 메시지
 


### PR DESCRIPTION
## 🔧 Version Code 경합 상태 및 APK 빌드 순서 문제 해결

### ⚠️ **문제 시나리오 1: 베타 릴리즈 경합 상태**

dev와 main 브랜치에 동시 머지 시 발생할 수 있는 경합 상태:

```
시간: 12:00:00 - PR #A dev 머지 → CD 시작 (VERSION_CODE=21 읽음)
시간: 12:02:00 - PR #B main 머지 → VERSION_CODE=21→22 업데이트  
시간: 12:05:00 - PR #A 베타 릴리즈 생성 (version code: 21 사용) ❌

결과: 베타가 구버전 코드 사용!
```

### ⚠️ **문제 시나리오 2: main 머지 시 APK 빌드 순서**

```
1. 베타 릴리즈: version code 21
2. main 머지 시작: APK 빌드 (version code 21 사용) ❌
3. 새 베타 릴리즈: version code 21 
4. main 릴리즈 완료: VERSION_CODE 21→22 업데이트 (하지만 APK는 이미 21로 빌드됨)
5. 3번 베타를 main에 머지: 
   - APK 빌드 시 version code 22 사용
   - VERSION_CODE 22→23 업데이트
   - 릴리즈 노트에 23 표시 ❌ (APK는 22인데 노트는 23)

결과: APK와 릴리즈 노트의 version code 불일치!
```

### 🎯 **문제점**

1. **Version Code 불일치**
   - 베타 릴리즈가 이미 업데이트된 version code 사용 못함
   - 릴리즈 버전과 베타 버전의 version code가 동일해짐

2. **APK 설치 문제**
   - 베타(21) → 릴리즈(21) → 다음 베타(21) 순서 시 문제
   - 사용자가 혼란스러운 버전 관리 경험

### ✨ **해결 방법**

#### 🔄 **1. 베타 릴리즈 생성 시 최신 VERSION_CODE 재확인**

```yaml
- name: Get Latest Version Code
  uses: actions/github-script@v7
  script: |
    // GitHub API로 최신 VERSION_CODE 다시 읽기
    const { data: variable } = await github.rest.actions.getRepoVariable({
      owner: context.repo.owner,
      repo: context.repo.repo,
      name: 'VERSION_CODE'
    });
    
    const latestVersionCode = variable.value;
    const originalVersionCode = '${{ needs.version-management.outputs.version_code }}';
    
    if (originalVersionCode !== latestVersionCode) {
      console.log(`⚠️ Version code changed during workflow execution!`);
      console.log(`Using latest version code: ${latestVersionCode}`);
    }
```

#### 🏗️ **2. main 머지 시 Version Code 업데이트 순서 변경**

**기존**: APK 빌드 → VERSION_CODE 업데이트
**개선**: VERSION_CODE 업데이트 → APK 빌드

```yaml
# 1단계: Version Code 먼저 업데이트
update-version-code:
  name: Update Version Code
  if: github.base_ref == 'main'
  steps:
    - name: Update Version Code
      script: |
        const newVersion = currentVersion + 1;
        await github.rest.actions.updateRepoVariable({
          name: 'VERSION_CODE',
          value: newVersion.toString()
        });

# 2단계: 업데이트된 Version Code로 APK 빌드
build-for-deploy-main:
  name: Build for Deploy (Main)
  needs: [update-version-code]
  steps:
    - name: Build APK
      env:
        VERSION_CODE: ${{ vars.VERSION_CODE }}  # 이미 업데이트된 값
```

#### 📝 **3. 릴리즈 노트에 변경 알림 추가**

```markdown
**Version Code**: 22
**⚠️ 참고**: 워크플로우 실행 중 Version Code가 업데이트되어 최신 값을 사용합니다.
```

### 🎯 **개선 효과**

#### **1. 베타 릴리즈 경합 상태 해결**
```
시간: 12:00:00 - PR #A dev 머지 → CD 시작 (VERSION_CODE=21)
시간: 12:02:00 - PR #B main 머지 → VERSION_CODE=21→22
시간: 12:05:00 - PR #A 베타 생성 시 최신 확인 → VERSION_CODE=22 사용 ✅

결과: 베타가 최신 version code 사용!
```

#### **2. main 머지 시 APK와 릴리즈 노트 일치**
```
기존 문제:
1. 베타 릴리즈: version code 21
2. main 머지: APK(21) + 릴리즈노트(22) ❌ 불일치!

개선 후:
1. 베타 릴리즈: version code 21  
2. main 머지: VERSION_CODE 21→22 업데이트
3. main 머지: APK(22) + 릴리즈노트(22) ✅ 일치!
```

#### **3. 사용자 시나리오 예상 결과**
```
1. 베타 릴리즈: version code 21
2. main에 머지 (아직 version code 21)
3. 새 베타 릴리즈: version code 21 (CD 먼저 완료)
4. main 릴리즈 완료: version code 22 (APK도 22로 빌드됨) ✅
5. 3번 베타를 main에 머지: 
   - VERSION_CODE 22→23 업데이트
   - APK version code 23으로 빌드 ✅
   - 릴리즈 노트에 23 표시 ✅

결과: APK와 릴리즈 노트 완전 일치!
```

### 🔍 **변경사항**

1. **워크플로우 작업 분리 및 순서 변경**
   - `build-for-deploy` → `build-for-deploy-dev` + `build-for-deploy-main`으로 분리
   - main 머지 시: `update-version-code` → `build-for-deploy-main` 순서로 실행
   - dev 머지 시: 기존 순서 유지

2. **`Get Latest Version Code` 스텝 추가**
   - GitHub API로 최신 VERSION_CODE 재확인
   - 변경 여부 감지 및 로깅

3. **릴리즈 노트 개선**
   - 최신 version code 사용
   - 변경 시 사용자에게 알림 표시

4. **의존성 관계 명확화**
   - dev: `build-for-deploy-dev` → `version-management` → `create-beta-release`
   - main: `update-version-code` → `build-for-deploy-main` → `create-release-tag` → `create-release`

5. **투명한 로깅**
   - 원본 vs 최신 version code 비교
   - 변경 감지 시 명확한 메시지

### 💡 **추가 고려사항**

- **성능 영향**: 추가 API 호출 1회 (무시할 수준)
- **안정성**: GitHub API 실패 시에도 기존 로직 유지
- **투명성**: 모든 변경사항이 로그와 릴리즈 노트에 기록

### 🧪 **테스트 방법**

1. dev PR과 main PR을 거의 동시에 머지
2. 베타 릴리즈의 version code가 최신 값 사용하는지 확인
3. 릴리즈 노트에 변경 알림 표시되는지 확인 