### PR TITLE
fix: 릴리즈 빌드 시 버전 정보 오류 수정

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -19,6 +19,10 @@ on:
         description: 'Build timestamp'
         required: true
         type: string
+      version_code:
+        description: 'Version code to use for build'
+        required: false
+        type: string
     outputs:
       artifact_name:
         description: 'Name of the uploaded artifact'
@@ -56,7 +60,7 @@ jobs:
       - name: Build Debug APK
         if: inputs.build_type == 'debug'
         env:
-          VERSION_CODE: ${{ vars.VERSION_CODE }}
+          VERSION_CODE: ${{ inputs.version_code || vars.VERSION_CODE }}
           BUILD_TIMESTAMP: ${{ inputs.timestamp }}
         run: |
           echo "Building debug APK with version code: $VERSION_CODE"
@@ -65,7 +69,7 @@ jobs:
       - name: Build Release APK
         if: inputs.build_type == 'release'
         env:
-          VERSION_CODE: ${{ vars.VERSION_CODE }}
+          VERSION_CODE: ${{ inputs.version_code || vars.VERSION_CODE }}
           BUILD_TIMESTAMP: ${{ inputs.timestamp }}
         run: |
           echo "Building release APK with version code: $VERSION_CODE"

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -42,6 +42,7 @@ jobs:
       branch_ref: ${{ github.event.pull_request.merge_commit_sha }}
       artifact_name: beta-build
       timestamp: ${{ needs.generate-timestamp.outputs.timestamp }}
+      version_code: ${{ vars.VERSION_CODE }}
 
   # 버전 관리 및 베타 태그 생성
   version-management:

--- a/.github/workflows/cd-main.yml
+++ b/.github/workflows/cd-main.yml
@@ -64,22 +64,11 @@ jobs:
           TZ: 'Asia/Seoul'
         run: echo "value=$(date +%Y%m%d%H%M%S)" >> $GITHUB_OUTPUT
 
-  # APK 빌드
-  build-apk:
-    name: Build Release APK
-    needs: [update-version-code, generate-timestamp]
-    uses: ./.github/workflows/build-apk.yml
-    with:
-      build_type: release
-      branch_ref: ${{ github.event.pull_request.merge_commit_sha }}
-      artifact_name: release-build
-      timestamp: ${{ needs.generate-timestamp.outputs.timestamp }}
-
   # 릴리즈 태그 생성
   create-release-tag:
     name: Create Release Tag
     runs-on: ubuntu-latest
-    needs: [build-apk, update-version-code]
+    needs: [update-version-code, generate-timestamp]
     permissions:
       contents: write
       actions: write
@@ -112,6 +101,18 @@ jobs:
           echo "Creating release tag: $release_tag"
           git tag -a "$release_tag" -m "Release $release_tag"
           git push origin "$release_tag"
+
+  # APK 빌드 (릴리즈 태그 생성 후)
+  build-apk:
+    name: Build Release APK
+    needs: [create-release-tag, generate-timestamp]
+    uses: ./.github/workflows/build-apk.yml
+    with:
+      build_type: release
+      branch_ref: ${{ needs.create-release-tag.outputs.release_tag }}
+      artifact_name: release-build
+      timestamp: ${{ needs.generate-timestamp.outputs.timestamp }}
+      version_code: ${{ needs.create-release-tag.outputs.new_version_code }}
 
   # 정식 릴리즈 생성
   create-production-release:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,18 +29,48 @@ fun getVersionFromTag(): Triple<Int, Int, Int> {
             )
         }
 
+        // 현재 커밋의 정확한 태그를 찾기 위해 여러 방법 시도
         val stdout = ByteArrayOutputStream()
+
+        // 1. 현재 커밋에 정확히 일치하는 태그가 있는지 확인
+        try {
+            exec {
+                commandLine("git", "describe", "--exact-match", "--tags", "HEAD")
+                standardOutput = stdout
+            }
+            val tag = stdout.toString().trim()
+            if (tag.isNotEmpty()) {
+                val version = tag.removePrefix("v").split(".")
+                return Triple(
+                    version.getOrNull(0)?.toIntOrNull() ?: 1,
+                    version.getOrNull(1)?.toIntOrNull() ?: 0,
+                    version.getOrNull(2)?.toIntOrNull() ?: 0,
+                )
+            }
+        } catch (e: Exception) {
+            // 정확한 태그가 없으면 다음 방법 시도
+        }
+
+        // 2. 가장 최근 태그 찾기 (beta 제외)
+        stdout.reset()
         exec {
-            commandLine("git", "describe", "--tags", "--abbrev=0")
+            commandLine("git", "tag", "-l", "v*", "--sort=-version:refname")
             standardOutput = stdout
         }
-        val tag = stdout.toString().trim()
-        val version = tag.removePrefix("v").split(".")
-        return Triple(
-            version.getOrNull(0)?.toIntOrNull() ?: 1,
-            version.getOrNull(1)?.toIntOrNull() ?: 0,
-            version.getOrNull(2)?.toIntOrNull() ?: 0,
-        )
+        val tags = stdout.toString().trim().split("\n")
+        val latestReleaseTag = tags.firstOrNull { !it.contains("beta") && it.startsWith("v") }
+
+        if (latestReleaseTag != null) {
+            val version = latestReleaseTag.removePrefix("v").split(".")
+            return Triple(
+                version.getOrNull(0)?.toIntOrNull() ?: 1,
+                version.getOrNull(1)?.toIntOrNull() ?: 0,
+                version.getOrNull(2)?.toIntOrNull() ?: 0,
+            )
+        }
+
+        // 3. 기본값
+        return Triple(1, 0, 0)
     } catch (e: Exception) {
         return Triple(1, 0, 0)
     }


### PR DESCRIPTION
## 🐛 버그 수정: 릴리즈 빌드 시 버전 정보 오류

### 📋 문제 상황
v1.2.0 릴리즈에서 GitHub Variables와 릴리즈 노트는 올바른 버전 정보를 표시했지만, 실제 APK 빌드에서는 이전 버전 정보가 사용되는 문제가 발생했습니다:

- **예상**: v1.2.0, 버전코드 22
- **실제**: v1.0.3, 버전코드 21

### 🔍 원인 분석

#### 1️⃣ **워크플로우 순서 문제**
```yaml
# 기존 (문제)
VERSION_CODE 업데이트 → APK 빌드 → 릴리즈 태그 생성

# 수정 후
VERSION_CODE 업데이트 → 릴리즈 태그 생성 → APK 빌드
```

#### 2️⃣ **VERSION_CODE 전달 문제**
- `build-apk.yml`에서 `${{ vars.VERSION_CODE }}`를 사용
- 업데이트된 새로운 값이 아닌 이전 값(21) 참조

#### 3️⃣ **Git 태그 참조 문제**
- `getVersionFromTag()`에서 `git describe --tags --abbrev=0` 사용
- merge_commit_sha 시점에서는 v1.0.3이 최신 태그로 인식

### 🔧 수정 내용

#### 1. **cd-main.yml 워크플로우 순서 변경**
```yaml
# APK 빌드를 릴리즈 태그 생성 후로 이동
build-apk:
  needs: [create-release-tag, generate-timestamp]
  with:
    branch_ref: ${{ needs.create-release-tag.outputs.release_tag }}
    version_code: ${{ needs.create-release-tag.outputs.new_version_code }}
```

#### 2. **build-apk.yml에 version_code 입력 추가**
```yaml
inputs:
  version_code:
    description: 'Version code to use for build'
    required: false
    type: string

env:
  VERSION_CODE: ${{ inputs.version_code || vars.VERSION_CODE }}
```

#### 3. **build.gradle.kts 태그 검색 로직 개선**
```kotlin
// 1. 현재 커밋에 정확히 일치하는 태그 확인
git describe --exact-match --tags HEAD

// 2. 가장 최근 릴리즈 태그 찾기 (beta 제외)
git tag -l "v*" --sort=-version:refname
```

#### 4. **cd-dev.yml도 동일하게 수정**
- 일관성을 위해 dev 브랜치에서도 version_code 전달

### ✅ 기대 효과

1. **정확한 버전 정보**: 릴리즈 태그 생성 후 빌드하여 올바른 버전 사용
2. **VERSION_CODE 동기화**: 업데이트된 새로운 버전 코드 정확히 전달
3. **태그 검색 안정성**: 여러 방법으로 정확한 태그 찾기
4. **일관성 보장**: dev/main 브랜치 모두 동일한 방식으로 처리

### 🧪 테스트 계획
- [ ] main 브랜치 머지 시 v1.2.0, 버전코드 22로 정확히 빌드되는지 확인
- [ ] dev 브랜치에서도 올바른 버전 정보 사용하는지 확인
- [ ] 태그 검색 로직이 다양한 상황에서 안정적으로 작동하는지 확인

### 📝 관련 이슈
- 릴리즈 빌드 버전 정보 불일치 문제 해결
- CI/CD 파이프라인 안정성 향상 