### PR TITLE
feat: 신규 프로젝트 버전 관리 개선

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -79,9 +79,10 @@ jobs:
           # PR 브랜치 이름에서 타입 추출
           branch_name="${{ github.head_ref }}"
           
-          # 기본값 설정
+          # 신규 프로젝트 또는 태그가 없는 경우 기본값 설정 (출시 전 상태)
           if [ -z "$latest_release" ]; then
-            major=1
+            echo "No release tags found. Starting with version 0.0.0 for new project."
+            major=0
             minor=0
             patch=0
           else
@@ -120,6 +121,20 @@ jobs:
             fi
           fi
           
+          # 신규 프로젝트에서 첫 번째 개발 시 버전 처리
+          if [ "$major" -eq 0 ] && [ "$minor" -eq 0 ] && [ "$patch" -eq 0 ]; then
+            if [[ "$branch_name" =~ ^feat/ ]]; then
+              # 첫 번째 기능 개발: 0.1.0
+              minor=1
+              patch=0
+              echo "First feature development: v0.1.0"
+            else
+              # 첫 번째 수정/개선: 0.0.1
+              patch=1
+              echo "First fix/improvement: v0.0.1"
+            fi
+          fi
+          
           next_version="$major.$minor.$patch"
           
           # 이전 베타 태그 찾기 (같은 버전의 가장 최신 베타)
@@ -127,6 +142,13 @@ jobs:
           
           # 새로운 베타 태그 생성 (현재 version code 사용)
           current_version_code="${{ vars.VERSION_CODE }}"
+          
+          # VERSION_CODE가 설정되지 않은 신규 프로젝트의 경우 기본값 사용
+          if [ -z "$current_version_code" ] || [ "$current_version_code" = "0" ]; then
+            current_version_code=1
+            echo "No VERSION_CODE found. Using default value: 1"
+          fi
+          
           beta_tag="v$next_version-beta.${{ needs.generate-timestamp.outputs.timestamp }}"
           echo "tag=$beta_tag" >> $GITHUB_OUTPUT
           echo "version=$next_version" >> $GITHUB_OUTPUT
@@ -139,7 +161,7 @@ jobs:
             echo "이전 베타 태그 발견: $previous_beta (릴리즈 작업에서 삭제 예정)"
           fi
           
-          echo "Creating beta tag: $beta_tag (version code: $current_version_code, based on $latest_release)"
+          echo "Creating beta tag: $beta_tag (version code: $current_version_code, based on ${latest_release:-'new project'})"
           git tag -a "$beta_tag" -m "Beta release $beta_tag (version code: $current_version_code)"
           git push origin "$beta_tag"
 

--- a/.github/workflows/cd-main.yml
+++ b/.github/workflows/cd-main.yml
@@ -90,15 +90,23 @@ jobs:
           
           latest_beta=$(git tag -l "v*-beta*" | sort -V | tail -n 1)
           if [ -z "$latest_beta" ]; then
-            echo "No beta tag found"
+            echo "❌ No beta tag found. Cannot create release without beta version."
+            echo "Please create a beta release first by merging to dev branch."
             exit 1
           fi
           
           version=$(echo $latest_beta | sed 's/^v\(.*\)-beta\..*/\1/')
+          
+          # 버전이 0.0.0인 경우 (신규 프로젝트) 경고 메시지
+          if [ "$version" = "0.0.0" ]; then
+            echo "⚠️  Warning: Creating release from version 0.0.0 (new project)"
+            echo "Consider using a proper version number for production release."
+          fi
+          
           release_tag="v$version"
           echo "tag=$release_tag" >> $GITHUB_OUTPUT
           
-          echo "Creating release tag: $release_tag"
+          echo "Creating release tag: $release_tag (from beta: $latest_beta)"
           git tag -a "$release_tag" -m "Release $release_tag"
           git push origin "$release_tag"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,7 +23,7 @@ fun getVersionFromTag(): Triple<Int, Int, Int> {
         System.getenv("BETA_VERSION")?.let { betaVersion ->
             val version = betaVersion.split(".")
             return Triple(
-                version.getOrNull(0)?.toIntOrNull() ?: 1,
+                version.getOrNull(0)?.toIntOrNull() ?: 0,
                 version.getOrNull(1)?.toIntOrNull() ?: 0,
                 version.getOrNull(2)?.toIntOrNull() ?: 0,
             )
@@ -42,7 +42,7 @@ fun getVersionFromTag(): Triple<Int, Int, Int> {
             if (tag.isNotEmpty()) {
                 val version = tag.removePrefix("v").split(".")
                 return Triple(
-                    version.getOrNull(0)?.toIntOrNull() ?: 1,
+                    version.getOrNull(0)?.toIntOrNull() ?: 0,
                     version.getOrNull(1)?.toIntOrNull() ?: 0,
                     version.getOrNull(2)?.toIntOrNull() ?: 0,
                 )
@@ -58,21 +58,23 @@ fun getVersionFromTag(): Triple<Int, Int, Int> {
             standardOutput = stdout
         }
         val tags = stdout.toString().trim().split("\n")
-        val latestReleaseTag = tags.firstOrNull { !it.contains("beta") && it.startsWith("v") }
+        val latestReleaseTag = tags.firstOrNull { !it.contains("beta") && it.startsWith("v") && it.trim().isNotEmpty() }
 
         if (latestReleaseTag != null) {
             val version = latestReleaseTag.removePrefix("v").split(".")
             return Triple(
-                version.getOrNull(0)?.toIntOrNull() ?: 1,
+                version.getOrNull(0)?.toIntOrNull() ?: 0,
                 version.getOrNull(1)?.toIntOrNull() ?: 0,
                 version.getOrNull(2)?.toIntOrNull() ?: 0,
             )
         }
 
-        // 3. 기본값
-        return Triple(1, 0, 0)
+        // 3. 신규 프로젝트 기본값 (출시 전 상태)
+        println("No release tags found. Using default version 0.0.0 for new project.")
+        return Triple(0, 0, 0)
     } catch (e: Exception) {
-        return Triple(1, 0, 0)
+        println("Error getting version from tag: ${e.message}. Using default version 0.0.0.")
+        return Triple(0, 0, 0)
     }
 }
 


### PR DESCRIPTION
# 🚀 Release v1.2.1 - 릴리즈 빌드 버전 정보 오류 수정

## 📋 릴리즈 개요
- **버전**: v1.2.1
- **타입**: 패치 릴리즈 (버그 수정)
- **베이스**: dev → main
- **예상 버전 코드**: 23

## 🔧 주요 변경사항

### 🐛 **Critical Fix: 릴리즈 빌드 버전 정보 오류 수정** (#46)
v1.2.0 릴리즈에서 발생한 심각한 버그를 수정했습니다:

#### 문제 상황
- **GitHub Variables**: v1.2.0, 버전코드 22 ✅
- **실제 APK 빌드**: v1.0.3, 버전코드 21 ❌

#### 해결 방법
1. **워크플로우 순서 변경**: 릴리즈 태그 생성 → APK 빌드
2. **VERSION_CODE 직접 전달**: 업데이트된 새로운 값 정확히 전달
3. **태그 검색 로직 개선**: 다단계 검색으로 정확한 태그 찾기

```yaml
# 수정 전 (문제)
VERSION_CODE 업데이트 → APK 빌드 → 릴리즈 태그 생성

# 수정 후 (해결)
VERSION_CODE 업데이트 → 릴리즈 태그 생성 → APK 빌드
```

## 🧪 **테스트 결과**
- ✅ **베타 빌드**: v1.2.1-beta.20250528101402 정상 생성
- ✅ **버전 정보**: 태그와 APK 버전 일치 확인
- ✅ **VERSION_CODE**: 22 → 23 예정

## 📝 **다음 단계**
1. **main 브랜치 머지**: VERSION_CODE 23으로 업데이트
2. **v1.2.1 정식 릴리즈**: 수정된 빌드 프로세스로 정확한 버전 생성
3. **모니터링**: 릴리즈 후 버전 정보 정확성 확인

---

**이 릴리즈는 v1.2.0에서 발생한 버전 정보 불일치 문제를 완전히 해결합니다.**

## 📋 변경사항

- branch protection 우회를 위한 ADMIN_TOKEN 사용
- 충돌 발생 시 자동으로 PR 생성하여 수동 해결 유도  
- 수동 실행 옵션 제공 (workflow_dispatch)
- 동기화 상태 요약 및 실패 알림 기능 포함

## 🎯 목적

v1.2.1 릴리즈 후 main → dev 브랜치 자동 동기화를 위한 워크플로우 추가

## 🔄 Git Flow

release/v1.2.1 브랜치 기준으로 feature 브랜치 생성하여 작업

## ✅ 테스트

- [x] 워크플로우 파일 문법 검증
- [x] YAML 구조 확인
- [x] 필요한 권한 설정 확인 

# 🆕 신규 프로젝트 버전 관리 개선

## 📋 변경사항 개요

신규 프로젝트에서 태그가 없을 때 발생할 수 있는 버전 관리 문제를 해결하고, 출시 전 상태인 0.0.0을 기본값으로 사용하도록 개선했습니다.

## 🔧 주요 변경사항

### **1. build.gradle.kts 개선**
- ✅ **기본 버전**: `1.0.0` → `0.0.0` (출시 전 상태)
- ✅ **예외 처리**: 태그 없는 프로젝트에서 안전한 기본값 사용
- ✅ **로깅 개선**: 버전 결정 과정 상세 출력
- ✅ **빈 태그 필터링**: 유효하지 않은 태그 제외

### **2. cd-dev.yml 개선**
- ✅ **신규 프로젝트 지원**: 태그 없이도 정상 작동
- ✅ **첫 개발 버전 로직**:
  - `feat/` 브랜치: `0.1.0` (첫 기능)
  - `fix/` 브랜치: `0.0.1` (첫 수정)
- ✅ **VERSION_CODE 기본값**: 미설정 시 1부터 시작
- ✅ **상세 로깅**: 버전 결정 과정 추적 가능

### **3. cd-main.yml 개선**
- ✅ **베타 태그 검증**: 릴리즈 전 베타 버전 필수 확인
- ✅ **0.x.x 경고**: 개발 버전 릴리즈 시 경고 메시지
- ✅ **명확한 에러**: 베타 태그 없을 시 구체적 안내

## 🎯 신규 프로젝트 시나리오

### **첫 번째 개발**
```bash
# feat/login 브랜치 → dev 머지
✅ 버전: v0.1.0-beta.20250528120000
✅ VERSION_CODE: 1

# fix/typo 브랜치 → dev 머지  
✅ 버전: v0.0.1-beta.20250528120000
✅ VERSION_CODE: 1
```

### **첫 번째 릴리즈**
```bash
# release/v0.1.0 → main 머지
✅ 릴리즈: v0.1.0
✅ VERSION_CODE: 2 (자동 증가)
⚠️  경고: 0.x.x 버전은 개발 단계
```

## 📊 버전 관리 규칙

| 상황 | 브랜치 타입 | 신규 프로젝트 | 기존 프로젝트 |
|------|------------|-------------|-------------|
| 첫 기능 | `feat/` | `0.1.0` | `minor++` |
| 첫 수정 | `fix/` | `0.0.1` | `patch++` |
| 핫픽스 | `hotfix/` | `0.0.1` | `patch++` |

## ✅ 테스트 완료

- [x] 신규 프로젝트에서 태그 없이 정상 작동
- [x] 기존 프로젝트에서 기존 로직 유지
- [x] 브랜치별 적절한 버전 증가
- [x] VERSION_CODE 기본값 처리
- [x] 에러 메시지 개선

## 🎉 기대 효과

1. **🆕 신규 프로젝트 즉시 사용 가능**: 태그 설정 없이도 워크플로우 작동
2. **📊 명확한 버전 관리**: 0.x.x로 개발 단계 명시
3. **🔧 안정성 향상**: 예외 상황에 대한 적절한 처리
4. **📝 투명성**: 상세한 로깅으로 디버깅 용이

---

**이 개선으로 워크플로우를 다른 신규 프로젝트에서도 바로 사용할 수 있습니다!** 🚀 