### PR TITLE
🚨 fix: 릴리즈 삭제 로직 및 중복 방지 개선

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -158,27 +158,27 @@ jobs:
             echo "삭제 API HTTP 상태 코드: $delete_http_code"
             
             if [ "$delete_http_code" = "204" ]; then
-              echo "이전 베타 릴리즈 삭제 완료: $release_id"
+              echo "✅ 이전 베타 릴리즈 삭제 완료: $release_id"
               
               # 릴리즈 삭제 성공 후 태그도 삭제
               echo "이전 베타 태그 삭제 중: $previous_beta"
               git tag -d "$previous_beta" 2>/dev/null || echo "로컬 태그가 없거나 이미 삭제됨"
               git push origin ":refs/tags/$previous_beta" 2>/dev/null || echo "원격 태그가 없거나 이미 삭제됨"
-              echo "이전 베타 태그 삭제 완료: $previous_beta"
+              echo "✅ 이전 베타 태그 삭제 완료: $previous_beta"
             else
-              echo "릴리즈 삭제 실패: HTTP $delete_http_code"
-              # 대안: 릴리즈를 Draft로 변경
-              echo "대안으로 릴리즈를 Draft 상태로 변경 시도..."
-              curl -s -X PATCH \
-                -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
-                -H "Content-Type: application/json" \
-                -d '{"draft": true}' \
-                "https://api.github.com/repos/${{ github.repository }}/releases/$release_id"
+              echo "❌ 릴리즈 삭제 실패: HTTP $delete_http_code"
+              echo "🔍 응답 내용: $delete_response"
+              echo "⚠️ 이전 베타 릴리즈 삭제에 실패했습니다."
+              echo "💡 수동으로 릴리즈 $previous_beta (ID: $release_id)를 삭제해주세요."
+              
+              # 삭제 실패 시에도 계속 진행 (새 릴리즈 생성은 가능)
+              echo "🔄 새로운 베타 릴리즈 생성을 계속 진행합니다..."
             fi
           else
-            echo "유효한 릴리즈 ID가 없음 - 태그만 삭제 시도"
+            echo "⚠️ 유효한 릴리즈 ID가 없음 - 태그만 삭제 시도"
             git tag -d "$previous_beta" 2>/dev/null || echo "로컬 태그가 없거나 이미 삭제됨"
             git push origin ":refs/tags/$previous_beta" 2>/dev/null || echo "원격 태그가 없거나 이미 삭제됨"
+            echo "✅ 태그 삭제 완료: $previous_beta"
           fi
 
       - name: Generate Beta Release Notes
@@ -234,7 +234,64 @@ jobs:
             git log --pretty=format:"- %s" ${previous_tag}..HEAD >> CHANGELOG.md
           fi
 
+      - name: Check for Existing Release
+        id: check-existing
+        run: |
+          TAG_NAME="${{ inputs.tag_name }}"
+          echo "기존 릴리즈 확인 중: $TAG_NAME"
+          
+          # GitHub API를 통해 기존 릴리즈 확인
+          api_response=$(curl -s -w "HTTPSTATUS:%{http_code}" \
+            -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/tags/$TAG_NAME")
+          
+          http_code=$(echo "$api_response" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+          
+          if [ "$http_code" = "200" ]; then
+            echo "⚠️ 경고: 태그 $TAG_NAME에 대한 릴리즈가 이미 존재합니다!"
+            
+            # 기존 릴리즈 정보 추출
+            response_body=$(echo "$api_response" | sed -e 's/HTTPSTATUS:.*//g')
+            existing_id=$(echo "$response_body" | jq -r '.id // empty')
+            existing_name=$(echo "$response_body" | jq -r '.name // empty')
+            is_draft=$(echo "$response_body" | jq -r '.draft // false')
+            
+            echo "기존 릴리즈 정보:"
+            echo "  - ID: $existing_id"
+            echo "  - 이름: $existing_name"
+            echo "  - Draft 상태: $is_draft"
+            
+            if [ "$is_draft" = "true" ]; then
+              echo "🔄 기존 릴리즈가 Draft 상태입니다. 삭제 후 새로 생성합니다."
+              
+              # Draft 릴리즈 삭제
+              delete_response=$(curl -s -w "HTTPSTATUS:%{http_code}" \
+                -X DELETE \
+                -H "Authorization: token ${{ secrets.ADMIN_TOKEN }}" \
+                "https://api.github.com/repos/${{ github.repository }}/releases/$existing_id")
+              
+              delete_http_code=$(echo "$delete_response" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+              
+              if [ "$delete_http_code" = "204" ]; then
+                echo "✅ Draft 릴리즈 삭제 완료"
+                echo "can_create=true" >> $GITHUB_OUTPUT
+              else
+                echo "❌ Draft 릴리즈 삭제 실패: HTTP $delete_http_code"
+                echo "can_create=false" >> $GITHUB_OUTPUT
+                exit 1
+              fi
+            else
+              echo "❌ 이미 게시된 릴리즈가 존재합니다. 새 릴리즈를 생성할 수 없습니다."
+              echo "can_create=false" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+          else
+            echo "✅ 기존 릴리즈가 없습니다. 새 릴리즈를 생성할 수 있습니다."
+            echo "can_create=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create Release
+        if: steps.check-existing.outputs.can_create == 'true'
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}


### PR DESCRIPTION
## 🚨 릴리즈 삭제 로직 및 중복 방지 개선

### 문제점
- v1.2.2 릴리즈가 2개 생성되고 기존 릴리즈가 Draft 처리되는 문제 발생
- `create-release.yml`의 베타 릴리즈 삭제 로직에 조건문 오류
- 삭제 실패 시 의도하지 않게 Draft 처리되어 혼란 야기

### 해결 내용

#### 1. 베타 릴리즈 삭제 로직 수정
- 조건문 로직 수정: 삭제 성공(204) vs 실패 처리 분리
- Draft 처리 로직 완전 제거 (혼란 방지)
- 삭제 실패 시에도 워크플로우 계속 진행하도록 개선

#### 2. 릴리즈 중복 방지 강화
- 릴리즈 생성 전 기존 릴리즈 존재 여부 확인
- Draft 상태 릴리즈 자동 삭제 기능 추가
- 이미 게시된 릴리즈 존재 시 워크플로우 중단

#### 3. 로깅 및 사용자 경험 개선
- 상세한 상태 메시지 및 이모지 추가
- 삭제 실패 시 수동 해결 가이드 제공
- API 응답 내용 로깅으로 디버깅 지원

### 테스트 계획
- 베타 릴리즈 생성 → 새 베타 릴리즈 생성 시 이전 릴리즈 정상 삭제 확인
- Draft 릴리즈 존재 시 자동 삭제 후 새 릴리즈 생성 확인
- 삭제 실패 시에도 새 릴리즈 정상 생성 확인

### 영향 범위
- `create-release.yml` 워크플로우만 수정
- 기존 릴리즈 생성 프로세스는 동일하게 유지
- 중복 릴리즈 및 Draft 처리 문제 해결 