### PR TITLE
🔧 fix: GitFlow 자동 동기화 로직 단순화

### DIFF
--- a/.github/workflows/gitflow-auto-sync.yml
+++ b/.github/workflows/gitflow-auto-sync.yml
@@ -56,16 +56,11 @@ jobs:
               source_branch="$current_branch"
               sync_reason="Release $current_branch 에 새 커밋 추가됨"
             elif [[ "$current_branch" == "main" ]]; then
-              # main 브랜치에서 최근 GitFlow 머지 확인
-              recent_commits=$(git log --oneline -3 --grep="Merge.*hotfix\|Merge.*release" || echo "")
-              if [[ -n "$recent_commits" ]]; then
-                echo "🔄 GitFlow 머지 커밋 감지:"
-                echo "$recent_commits"
-                should_sync="true"
-                sync_type="main_push"
-                source_branch="main"
-                sync_reason="Main 브랜치에 GitFlow 머지 커밋 감지"
-              fi
+              echo "🔄 Main 브랜치에 새 커밋 감지 - 자동 동기화 실행"
+              should_sync="true"
+              sync_type="main_push"
+              source_branch="main"
+              sync_reason="Main 브랜치에 새 커밋 추가됨 - GitFlow 동기화 필요"
             fi
           fi
           


### PR DESCRIPTION
## 🔧 GitFlow 자동 동기화 로직 단순화

### 문제점
- dev가 main보다 2 commits behind 상태로 동기화 중단
- main 브랜치에서 GitFlow 머지 커밋만 감지하여 일반 커밋 무시
- skip-ci 릴리즈 시 동기화 작동 안함
- 불필요한 릴리즈 타입 구분으로 복잡성 증가

### 해결 방안
- **단순화된 감지 로직**: main 브랜치의 모든 푸시에 대해 동기화 실행
- **필터링 제거**: GitFlow 머지 커밋 패턴 매칭 로직 삭제
- **완전 동기화**: Fast-forward로 누락된 모든 커밋 동기화
- **skip-ci 지원**: 커밋 타입에 관계없이 동기화 실행

### 변경사항
- `main` 브랜치 푸시 시 조건부 감지 → 무조건 동기화
- GitFlow 머지 커밋 grep 검사 로직 제거
- 동기화 이유 메시지 단순화

### 기대 효과
- dev 브랜치가 main과 항상 동기화 상태 유지
- skip-ci 릴리즈도 정상 동기화
- 워크플로우 로직 단순화로 유지보수성 향상
- GitFlow 원칙에 맞는 브랜치 동기화 보장 